### PR TITLE
[Chore] CD 트리거 브랜치를 main으로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: CD (Deploy to Lightsail)
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "main" ]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

CD 배포 트리거 브랜치를 `dev`에서 `main`으로 변경합니다.

## Changes

- CD 워크플로우 트리거 브랜치 변경 (`dev` → `main`)
- GitFlow 브랜치 전략 적용

## Type of Change

- [x] Chore (빌드, 설정 등)

## Related Issues

- N/A (설정 개선)

## Testing

- [ ] GitHub Actions 워크플로우 확인

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] 커밋 메시지 컨벤션을 준수했습니다 (`docs/development/CONVENTIONS.md`)

## Additional Notes

**변경 후 브랜치 전략:**
- `feature/*` → `dev` (PR) → `main` (PR) → 자동 배포
- Default branch: `dev` (개발 코드 모이는 곳)
- Production branch: `main` (배포 트리거)