### PR TITLE
Fix: 인증 쿠키 경로 누락 및 TypeORM 엔티티 로드 문제 수정

### DIFF
--- a/src/config/typeorm-config.ts
+++ b/src/config/typeorm-config.ts
@@ -16,7 +16,7 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
             username: this.configService.get('DB_USERNAME'),
             password: this.configService.get('DB_PASSWORD'),
             database: this.configService.get('DB_SCHEMA'),
-            entities: [__dirname + '/../modules/**/*.entity.{ts,js}'],
+            autoLoadEntities: true,
             synchronize: !isProd,
             logging: !isProd ? ['error', 'query'] : false,
         };

--- a/src/modules/auth/presentation/auth.controller.ts
+++ b/src/modules/auth/presentation/auth.controller.ts
@@ -79,6 +79,7 @@ export class AuthController {
             httpOnly: true,
             secure: this.configService.get<string>('APP_PROFILE') === 'prod',
             sameSite: 'lax',
+            path: '/',
             maxAge: TimeUtil.toMs(expiresIn),
         });
         const clientUrl = this.configService.getOrThrow<string>('CLIENT_REDIRECT_URI');


### PR DESCRIPTION
<!--
PR 제목 형식: TYPE: 설명 (#이슈번호)
예시: Feat: 포트폴리오 CRUD API 구현 (#15)

TYPE: Feat, Fix, Refactor, Chore, Docs, Test, Style
-->

## Summary
배포환경의 로그인 프로세스 및 DB 초기화 과정에서 발견된 두 가지 크리티컬한 이슈를 수정했습니다.

## Changes

- 쿠키에 path 옵션 추가
- TypeORM entities 옵션 제거 및 autoLoadEntities 옵션 추가

## Type of Change

- [x] Bug fix (기존 기능을 수정하는 변경)
- [x] Chore (빌드, 설정 등)

## Related Issues
- 없음

## Testing

- [x] Postman/Swagger로 API 호출 확인

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] 커밋 메시지 컨벤션을 준수했습니다 (`docs/development/CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint`)

## Additional Notes
1. Refresh Token 쿠키 설정 수정
- **문제:** 로컬 테스트 시엔 작동했으나, 배포환경에서 실제 쿠키가 루트 경로(`/`)에서 유효하지 않아 인증이 풀리는 현상 발생.
- **해결:** `res.cookie` 옵션에 **`path: '/'`**를 명시하여 사이트 전역에서 쿠키가 유지되도록 수정.

2. TypeORM 설정 개선
- **문제:** `entities` 경로 설정이 빌드된 파일 위치와 맞지 않아, `synchronize: true`임에도 테이블이 생성되지 않음.
- **해결:** 경로 의존성을 제거하고 **`autoLoadEntities: true`** 옵션을 사용하여 모듈에 등록된 엔티티를 자동으로 로드하도록 변경.