### PR TITLE
Fix: CD 워크플로우 Secret 이름 통일 (#54)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,9 +69,9 @@ jobs:
             - name: Copy docker-compose.dev.yml to Server
               uses: appleboy/scp-action@master
               with:
-                  host: ${{ secrets.LIGHTSAIL_HOST_DEV }}
-                  username: ${{ secrets.LIGHTSAIL_USERNAME_DEV }}
-                  key: ${{ secrets.LIGHTSAIL_SSH_KEY_DEV }}
+                  host: ${{ secrets.LIGHTSAIL_HOST }}
+                  username: ${{ secrets.LIGHTSAIL_USERNAME }}
+                  key: ${{ secrets.LIGHTSAIL_SSH_KEY }}
                   port: 22
                   source: 'docker-compose.dev.yml'
                   target: '~/docker'
@@ -82,9 +82,9 @@ jobs:
               env:
                   ENV_DEV: ${{ secrets.ENV_DEV }}
               with:
-                  host: ${{ secrets.LIGHTSAIL_HOST_DEV }}
-                  username: ${{ secrets.LIGHTSAIL_USERNAME_DEV }}
-                  key: ${{ secrets.LIGHTSAIL_SSH_KEY_DEV }}
+                  host: ${{ secrets.LIGHTSAIL_HOST }}
+                  username: ${{ secrets.LIGHTSAIL_USERNAME }}
+                  key: ${{ secrets.LIGHTSAIL_SSH_KEY }}
                   port: 22
                   envs: ENV_DEV
                   script: |
@@ -129,9 +129,9 @@ jobs:
             - name: Copy docker-compose.prod.yml to Server
               uses: appleboy/scp-action@master
               with:
-                  host: ${{ secrets.LIGHTSAIL_HOST_PROD }}
-                  username: ${{ secrets.LIGHTSAIL_USERNAME_PROD }}
-                  key: ${{ secrets.LIGHTSAIL_SSH_KEY_PROD }}
+                  host: ${{ secrets.LIGHTSAIL_HOST }}
+                  username: ${{ secrets.LIGHTSAIL_USERNAME }}
+                  key: ${{ secrets.LIGHTSAIL_SSH_KEY }}
                   port: 22
                   source: 'docker-compose.prod.yml'
                   target: '~/docker'
@@ -142,9 +142,9 @@ jobs:
               env:
                   ENV_PROD: ${{ secrets.ENV_PROD }}
               with:
-                  host: ${{ secrets.LIGHTSAIL_HOST_PROD }}
-                  username: ${{ secrets.LIGHTSAIL_USERNAME_PROD }}
-                  key: ${{ secrets.LIGHTSAIL_SSH_KEY_PROD }}
+                  host: ${{ secrets.LIGHTSAIL_HOST }}
+                  username: ${{ secrets.LIGHTSAIL_USERNAME }}
+                  key: ${{ secrets.LIGHTSAIL_SSH_KEY }}
                   port: 22
                   envs: ENV_PROD
                   script: |


### PR DESCRIPTION
## Summary

PR #53에서 변경된 Secret 이름(`_DEV`, `_PROD` 접미사)이 실제 GitHub Secrets에 등록되지 않아 dev 배포 실패하는 문제 수정

## Changes

- deploy-dev job: `LIGHTSAIL_HOST_DEV` → `LIGHTSAIL_HOST` 등 접미사 제거
- deploy-prod job: `LIGHTSAIL_HOST_PROD` → `LIGHTSAIL_HOST` 등 접미사 제거
- dev/prod 동일 서버 사용으로 SSH Secret을 하나로 통일

## Type of Change

- [x] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [ ] Documentation (문서 변경)
- [ ] Chore (빌드, 설정 등)

## Target Environment

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

- Closes #54

## Testing

- [x] deploy.yml 변경 내용 확인 (Secret 이름이 기존 등록된 이름과 일치)

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)

## Additional Notes

`ENV_DEV`, `ENV_PROD`는 각각 다른 환경변수이므로 기존 이름 유지.
SSH 접속 관련 Secret(`LIGHTSAIL_HOST`, `LIGHTSAIL_USERNAME`, `LIGHTSAIL_SSH_KEY`)만 통일.