### PR TITLE
Docs: AI 어시스턴트 컨텍스트 및 스타일 가이드에 아키텍처 규칙 반영 (#59)

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -46,8 +46,22 @@
 
 1. **의존성 주입**: 생성자 주입 패턴 준수 여부
 2. **데코레이터 사용**: Swagger, Validation 데코레이터 적절성
-3. **예외 처리**: `BusinessException` + `ErrorCode` 사용 여부 (NestJS 내장 예외 사용 금지)
-4. **모듈 구조**: 도메인별 모듈 분리 적절성
+3. **모듈 구조**: 도메인별 모듈 분리 적절성
+
+## 예외 처리 리뷰 항목
+
+### 우선순위 높음 (반드시 지적)
+
+1. **NestJS 내장 예외 사용**: `NotFoundException`, `BadRequestException` 등 내장 예외 사용 시 → `BusinessException` + `ErrorCode` 사용으로 변경 요구
+2. **Controller에서 비즈니스 에러 throw**: Controller가 직접 `BusinessException`을 throw하는 경우 → Service/Repository에서 처리하도록 변경 요구
+3. **빈 catch 블록**: `catch(e) {}` 처럼 에러를 무시하는 경우
+
+### 우선순위 중간
+
+4. **ErrorCode 미등록**: `error-code.enum.ts`에 코드만 추가하고 `error-code.ts`에 매핑 누락
+5. **ErrorCode 네이밍 위반**: `<DOMAIN><HTTP_STATUS><SEQUENCE?>` 형식을 따르지 않는 경우
+6. **계층별 에러 책임 위반**: Repository가 비즈니스 로직 에러를 throw하거나, Service가 NOT_FOUND를 직접 처리하는 경우
+7. **Swagger 에러 문서 누락**: Controller 메서드에 `@ApiCommonErrorResponse` 데코레이터가 빠진 경우
 
 ## 아키텍처 규칙 리뷰 항목
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ Folioo는 포트폴리오 관리 및 첨삭 플랫폼입니다. NestJS + TypeORM
 | 도메인 전략   | `docs/architecture/DOMAIN_STRATEGY.md`   |
 | ERD/DB 설계   | `docs/architecture/ERD.md`               |
 | 코드 스타일   | `docs/development/CODE_STYLE.md`         |
+| 예외 처리     | `docs/development/ERROR_HANDLING.md`     |
 | Git 컨벤션    | `docs/development/GIT_CONVENTIONS.md`    |
 | 네이밍 컨벤션 | `docs/development/NAMING_CONVENTIONS.md` |
 | PR 템플릿     | `.github/PULL_REQUEST_TEMPLATE.md`       |
@@ -57,11 +58,23 @@ async getProfile(userId: number): Promise<UserResDto> {
 }
 ```
 
-### 2. 예외 클래스
+### 2. 예외 처리 규칙
 
-- 커스텀 예외: `BusinessException`
+- 커스텀 예외: `BusinessException` (유일하게 허용되는 예외 클래스)
 - 에러 코드: `ErrorCode` enum
 - 위치: `src/common/exceptions/`
+- **NestJS 내장 예외 사용 금지** (`NotFoundException`, `BadRequestException` 등)
+- ErrorCode 네이밍: `<DOMAIN><HTTP_STATUS><SEQUENCE?>` (예: `USER404`, `EXPERIENCE4091`)
+- 새 에러 추가 시: `error-code.enum.ts` + `error-code.ts` 두 파일 모두 수정
+- 상세 가이드: `docs/development/ERROR_HANDLING.md`
+
+```typescript
+// ✅ 올바른 사용
+throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+
+// ❌ 금지
+throw new NotFoundException('User not found');
+```
 
 ### 3. DTO 네이밍
 

--- a/docs/development/CODE_STYLE.md
+++ b/docs/development/CODE_STYLE.md
@@ -413,27 +413,41 @@ this.logger.log(`User created: ${user.id}`);
 ### 1. 일관된 에러 처리
 
 프로젝트에서 정의한 `BusinessException`과 `ErrorCode`를 사용하여 에러를 처리합니다.
+**NestJS 내장 예외(`NotFoundException`, `BadRequestException` 등)는 사용하지 않습니다.**
 
 ```typescript
-// error-code.enum.ts
-export enum ErrorCode {
-    // 공통
-    BAD_REQUEST = 'COMMON400',
-    UNAUTHORIZED = 'COMMON401',
-    INTERNAL_SERVER_ERROR = 'COMMON500',
-    NOT_IMPLEMENTED = 'COMMON501',
-
-    // 도메인별 에러 코드 추가
-    USER_NOT_FOUND = 'USER404',
-}
-
-// 서비스에서 사용
-throw new BusinessException(ErrorCode.BAD_REQUEST);
-throw new BusinessException(ErrorCode.UNAUTHORIZED);
+// ✅ 올바른 사용
 throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+throw new BusinessException(ErrorCode.BAD_REQUEST);
+
+// ✅ 추가 디버깅 정보가 필요한 경우 details 사용
+throw new BusinessException(ErrorCode.USER_NOT_FOUND, { requestedId: userId });
+
+// ❌ 금지 — NestJS 내장 예외 사용
+throw new NotFoundException('User not found');
+throw new BadRequestException('Invalid input');
 ```
 
-> 참고: `common/exceptions/` 디렉토리의 `error-code.enum.ts`, `error-code.ts`, `business.exception.ts` 파일 참조
+### ErrorCode 네이밍 규칙
+
+```
+<DOMAIN><HTTP_STATUS><SEQUENCE?>
+```
+
+- enum name: `SCREAMING_SNAKE_CASE` (의미가 명확하게 드러나야 함)
+- enum value: `도메인 접두사` + `HTTP 상태 코드` + `구분 번호(선택)`
+- 새 에러 코드 추가 시: `error-code.enum.ts`에 코드, `error-code.ts`에 메시지+상태 코드 매핑 모두 추가
+
+```typescript
+// 기본: DOMAIN + HTTP_STATUS
+USER_NOT_FOUND = 'USER404';
+
+// 동일 도메인+상태 코드가 여러 개: SEQUENCE 추가
+DUPLICATE_EXPERIENCE_NAME = 'EXPERIENCE4091';
+EXPERIENCE_MAX_LIMIT = 'EXPERIENCE4092';
+```
+
+> 상세 가이드: `docs/development/ERROR_HANDLING.md` 참조
 
 ### 2. Optional Chaining 사용
 

--- a/docs/development/ERROR_HANDLING.md
+++ b/docs/development/ERROR_HANDLING.md
@@ -1,0 +1,346 @@
+# 예외 처리 가이드
+
+## 개요
+
+Folioo 서버는 **NestJS 내장 예외를 사용하지 않고**, 자체 정의한 `BusinessException` + `ErrorCode`를 통해 일관된 에러 처리를 수행합니다.
+
+## 아키텍처
+
+```
+throw BusinessException(ErrorCode)
+        ↓
+  GlobalExceptionFilter (@Catch)
+        ↓
+  CommonResponse.fail()  ←  표준화된 에러 응답
+        ↓
+  (500 이상일 경우 Sentry 전송)
+```
+
+### 핵심 컴포넌트
+
+| 컴포넌트                 | 위치                                            | 역할                                      |
+| ------------------------ | ----------------------------------------------- | ----------------------------------------- |
+| `BusinessException`      | `src/common/exceptions/business.exception.ts`   | 커스텀 예외 클래스 (`HttpException` 확장) |
+| `ErrorCode` (enum)       | `src/common/exceptions/error-code.enum.ts`      | 에러 코드 열거형 정의                     |
+| `ErrorMap`               | `src/common/exceptions/error-code.ts`           | 에러 코드 → 메시지 + HTTP 상태 코드 매핑  |
+| `GlobalExceptionFilter`  | `src/common/filters/global-exception.filter.ts` | 전역 예외 필터 (Sentry 연동)              |
+| `CommonResponse`         | `src/common/dtos/common-response.dto.ts`        | 표준 응답 래퍼 클래스                     |
+| `ApiCommonErrorResponse` | `src/common/decorators/swagger.decorator.ts`    | Swagger 에러 문서화 데코레이터            |
+
+## ErrorCode 네이밍 규칙
+
+### 형식
+
+```
+<DOMAIN><HTTP_STATUS><SEQUENCE?>
+```
+
+| 구성 요소     | 설명                                      | 예시           |
+| ------------- | ----------------------------------------- | -------------- |
+| `DOMAIN`      | 도메인 접두사 (대문자)                    | `USER`, `AUTH` |
+| `HTTP_STATUS` | HTTP 상태 코드 (3자리)                    | `404`, `409`   |
+| `SEQUENCE`    | 동일 도메인+상태 코드 내 구분 번호 (선택) | `1`, `2`       |
+
+### enum name 규칙
+
+- **대문자 + 언더스코어** (`SCREAMING_SNAKE_CASE`)
+- 의미가 명확하게 드러나야 함
+
+### 예시
+
+```typescript
+// 기본 형식: DOMAIN + HTTP_STATUS
+USER_NOT_FOUND = 'USER404';
+PORTFOLIO_NOT_FOUND = 'PORTFOLIO404';
+
+// 동일 도메인 + 상태 코드가 여러 개인 경우: SEQUENCE 추가
+DUPLICATE_EXPERIENCE_NAME = 'EXPERIENCE4091'; // 첫 번째 409
+EXPERIENCE_MAX_LIMIT = 'EXPERIENCE4092'; // 두 번째 409
+
+// 공통 에러
+BAD_REQUEST = 'COMMON400';
+UNAUTHORIZED = 'COMMON401';
+INTERNAL_SERVER_ERROR = 'COMMON500';
+```
+
+### 현재 도메인별 에러 코드 목록
+
+| 도메인         | ErrorCode                         | 값               | HTTP 상태 | 메시지                                                                |
+| -------------- | --------------------------------- | ---------------- | --------- | --------------------------------------------------------------------- |
+| **Common**     | `BAD_REQUEST`                     | `COMMON400`      | 400       | 잘못된 요청입니다.                                                    |
+|                | `UNAUTHORIZED`                    | `COMMON401`      | 401       | 유효하지 않은 사용자입니다.                                           |
+|                | `INTERNAL_SERVER_ERROR`           | `COMMON500`      | 500       | 잠시 후 다시 시도해주세요.                                            |
+|                | `NOT_IMPLEMENTED`                 | `COMMON501`      | 501       | 아직 구현되지 않은 기능입니다.                                        |
+| **Auth**       | `ALREADY_VERIFY_USER`             | `AUTH409`        | 409       | 이미 인증 이력이 있는 번호입니다.                                     |
+|                | `SMS_CODE_NOT_FOUND`              | `AUTH_CODE404`   | 404       | 인증 시간이 만료되었습니다. 재전송 버튼을 눌러주세요.                 |
+|                | `SMS_CODE_MISMATCH`               | `AUTH_CODE400`   | 400       | 인증 번호가 일치하지 않습니다. 다시 확인해 주세요.                    |
+|                | `REFRESH_TOKEN_EXPIRED`           | `AUTH4011`       | 401       | 리프레시 토큰이 만료되었습니다. 다시 로그인해주세요.                  |
+|                | `REFRESH_TOKEN_MISSING`           | `AUTH4012`       | 401       | 리프레시 토큰이 없습니다.                                             |
+|                | `INVALID_REFRESH_TOKEN`           | `AUTH4013`       | 401       | 유효하지 않은 토큰입니다.                                             |
+| **User**       | `USER_NOT_FOUND`                  | `USER404`        | 404       | 해당하는 사용자를 찾을 수 없습니다.                                   |
+| **Credit**     | `INSUFFICIENT_CREDITS`            | `CREDIT402`      | 402       | 크레딧이 부족합니다.                                                  |
+| **Insight**    | `LOG_NOT_FOUND`                   | `LOG404`         | 404       | 해당하는 인사이트 로그를 찾을 수 없습니다.                            |
+|                | `DUPLICATE_LOG_NAME`              | `LOG409`         | 409       | 인사이트 로그의 제목은 중복될 수 없습니다.                            |
+|                | `ACTIVITY_NOT_FOUND`              | `ACTIVITY404`    | 404       | 해당하는 활동 분류 태그를 찾을 수 없습니다.                           |
+|                | `DUPLICATE_ACTIVITY_NAME`         | `ACTIVITY4091`   | 409       | 활동명은 중복될 수 없습니다.                                          |
+|                | `FULL_ACTIVITY_NAME`              | `ACTIVITY4092`   | 409       | 활동 분류 태그는 최대 10개까지 가질 수 있습니다.                      |
+| **Experience** | `EXPERIENCE_NOT_FOUND`            | `EXPERIENCE404`  | 404       | 해당하는 경험을 찾을 수 없습니다.                                     |
+|                | `DUPLICATE_EXPERIENCE_NAME`       | `EXPERIENCE4091` | 409       | 경험 정리 제목은 중복될 수 없습니다.                                  |
+|                | `EXPERIENCE_MAX_LIMIT`            | `EXPERIENCE4092` | 409       | 경험 정리는 최대 15개까지 가질 수 있습니다.                           |
+| **Portfolio**  | `PORTFOLIO_NOT_FOUND`             | `PORTFOLIO404`   | 404       | 해당하는 포트폴리오를 찾을 수 없습니다.                               |
+| **Correction** | `CORRECTION_NOT_FOUND`            | `CORRECTION404`  | 404       | 해당하는 첨삭 결과를 찾을 수 없습니다.                                |
+|                | `CORRECTION_MAX_LIMIT`            | `CORRECTION4091` | 409       | 포트폴리오 첨삭은 최대 15개까지 가질 수 있습니다.                     |
+|                | `CORRECTION_BLOCK_LIMIT_EXCEEDED` | `CORRECTION4092` | 409       | 포트폴리오 첨삭은 최대 5개의 활동블록(포트폴리오)을 가질 수 있습니다. |
+
+## 새 에러 코드 추가 방법
+
+### Step 1: ErrorCode enum에 코드 추가
+
+```typescript
+// src/common/exceptions/error-code.enum.ts
+export enum ErrorCode {
+    // ... 기존 코드
+
+    // 새 도메인 에러
+    NEW_DOMAIN_ERROR = 'DOMAIN400',
+}
+```
+
+### Step 2: ErrorMap에 메시지 + 상태 코드 매핑 추가
+
+```typescript
+// src/common/exceptions/error-code.ts
+export const ErrorMap: Record<ErrorCode, ErrorDetail> = {
+    // ... 기존 매핑
+
+    [ErrorCode.NEW_DOMAIN_ERROR]: {
+        message: '사용자 친화적인 한국어 에러 메시지',
+        statusCode: HttpStatus.BAD_REQUEST,
+    },
+};
+```
+
+### Step 3: 서비스/리포지토리에서 사용
+
+```typescript
+throw new BusinessException(ErrorCode.NEW_DOMAIN_ERROR);
+
+// 추가 상세 정보가 필요한 경우 details 파라미터 사용
+throw new BusinessException(ErrorCode.NEW_DOMAIN_ERROR, { field: 'email' });
+```
+
+## 계층별 에러 처리 책임
+
+### 설계 배경
+
+NOT_FOUND 에러를 Service에서 처리하면 계층 분리는 명확하지만, **모든 조회마다 null 체크 보일러플레이트가 반복**됩니다. 팀 논의 결과, NOT_FOUND처럼 **데이터 존재 여부와 직접 관련된 에러는 Repository에서 처리**하여 코드 간결성을 확보하기로 결정했습니다.
+
+```typescript
+// ❌ Service에서 매번 null 체크 — 보일러플레이트 과다
+async getProfile(userId: number): Promise<UserResDto> {
+    const user = await this.userRepository.findById(userId);
+    if (!user) {
+        throw new BusinessException(ErrorCode.USER_NOT_FOUND); // 매번 반복
+    }
+    return UserResDto.from(user);
+}
+
+// ✅ Repository의 findByIdOrThrow 사용 — 간결하고 일관됨
+async getProfile(userId: number): Promise<UserResDto> {
+    const user = await this.userRepository.findByIdOrThrow(userId);
+    return UserResDto.from(user);
+}
+```
+
+### 정리
+
+| 계층           | 에러 종류                           | 예시                                           |
+| -------------- | ----------------------------------- | ---------------------------------------------- |
+| **Repository** | 데이터 존재 여부 (NOT_FOUND)        | `findByIdOrThrow` → `USER_NOT_FOUND`           |
+| **Service**    | 비즈니스 로직 (검증, 제한, 중복 등) | `EXPERIENCE_MAX_LIMIT`, `DUPLICATE_*`          |
+| **Controller** | 입력 검증만                         | `ValidationPipe` + `class-validator` 자동 처리 |
+
+### Repository 계층 — 데이터 접근 에러
+
+```typescript
+@Injectable()
+export class UserRepository {
+    // NOT_FOUND 에러를 throw하는 조회
+    async findByIdOrThrow(id: number): Promise<User> {
+        const user = await this.userRepository.findOne({ where: { id } });
+        if (!user) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+        return user;
+    }
+
+    // null 반환 허용 (존재 여부 확인용)
+    async findByEmail(email: string): Promise<User | null> {
+        return await this.userRepository.findOne({ where: { email } });
+    }
+}
+```
+
+### Service 계층 — 비즈니스 로직 에러
+
+```typescript
+@Injectable()
+export class ExperienceService {
+    async validateCreation(userId: number, name: string): Promise<void> {
+        // 개수 제한 검증
+        const count = await this.experienceRepository.countByUserId(userId);
+        if (count >= MAX_EXPERIENCES_PER_USER) {
+            throw new BusinessException(ErrorCode.EXPERIENCE_MAX_LIMIT);
+        }
+
+        // 중복 검증
+        const isDuplicate = await this.experienceRepository.existsByName(userId, name);
+        if (isDuplicate) {
+            throw new BusinessException(ErrorCode.DUPLICATE_EXPERIENCE_NAME);
+        }
+    }
+}
+```
+
+### Controller 계층 — 입력 검증만
+
+Controller에서는 **직접 예외를 throw하지 않습니다**. 입력 검증은 `ValidationPipe` + `class-validator` 데코레이터로 자동 처리됩니다.
+
+```typescript
+@Controller('experiences')
+export class ExperienceController {
+    @Post()
+    async create(@Body() dto: CreateExperienceReqDto): Promise<ExperienceResDto> {
+        // ✅ DTO의 class-validator로 입력 검증 자동 처리
+        // ✅ 비즈니스 에러는 Service/Repository에서 throw
+        return this.experienceService.create(dto);
+    }
+}
+```
+
+### Repository 메서드 네이밍 컨벤션
+
+| 메서드 패턴      | 반환 타입                 | 용도                             |
+| ---------------- | ------------------------- | -------------------------------- |
+| `findByXOrThrow` | `Promise<Entity>`         | 없으면 `BusinessException` throw |
+| `findByX`        | `Promise<Entity \| null>` | 없으면 `null` 반환 (존재 확인용) |
+
+## 응답 형식
+
+### 성공 응답
+
+```json
+{
+    "timestamp": "2024-01-02T12:34:56.000Z",
+    "isSuccess": true,
+    "error": null,
+    "result": { ... }
+}
+```
+
+### 에러 응답
+
+```json
+{
+    "timestamp": "2024-01-02T12:34:56.000Z",
+    "isSuccess": false,
+    "error": {
+        "errorCode": "USER404",
+        "reason": "해당하는 사용자를 찾을 수 없습니다.",
+        "details": null,
+        "path": "/api/users/999"
+    },
+    "result": null
+}
+```
+
+## Swagger 에러 문서화
+
+`@ApiCommonErrorResponse` 데코레이터를 사용하여 Controller 메서드에 발생 가능한 에러를 문서화합니다.
+
+```typescript
+@Get(':id')
+@ApiOperation({ summary: '사용자 조회' })
+@ApiCommonResponse(UserResDto)
+@ApiCommonErrorResponse(ErrorCode.USER_NOT_FOUND, ErrorCode.UNAUTHORIZED)
+async findOne(@Param('id') id: string): Promise<UserResDto> {
+    return this.userService.findOne(id);
+}
+```
+
+동일한 HTTP 상태 코드를 가진 에러가 여러 개인 경우, Swagger UI에서 examples 드롭다운으로 각각 확인할 수 있습니다.
+
+## 금지 사항
+
+### 1. NestJS 내장 예외 사용 금지
+
+```typescript
+// ❌ 금지
+throw new NotFoundException('User not found');
+throw new BadRequestException('Invalid input');
+throw new UnauthorizedException();
+throw new ForbiddenException();
+throw new ConflictException();
+
+// ✅ 올바른 사용
+throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+throw new BusinessException(ErrorCode.BAD_REQUEST);
+throw new BusinessException(ErrorCode.UNAUTHORIZED);
+```
+
+### 2. 에러 메시지 하드코딩 금지
+
+```typescript
+// ❌ 금지 — 메시지가 ErrorMap과 중복/불일치
+throw new BusinessException(ErrorCode.USER_NOT_FOUND, '사용자를 찾을 수 없습니다');
+
+// ✅ 올바른 사용 — 메시지는 ErrorMap에서 자동 매핑
+throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+
+// ✅ details는 디버깅용 추가 정보로 사용 가능
+throw new BusinessException(ErrorCode.USER_NOT_FOUND, { requestedId: userId });
+```
+
+### 3. Controller에서 직접 예외 throw 금지
+
+```typescript
+// ❌ 금지 — Controller에서 비즈니스 에러 throw
+@Post()
+async create(@Body() dto: CreateUserReqDto) {
+    if (await this.userService.existsByEmail(dto.email)) {
+        throw new BusinessException(ErrorCode.EMAIL_ALREADY_EXISTS); // 이건 Service 책임
+    }
+}
+
+// ✅ 올바른 사용 — Service에 위임
+@Post()
+async create(@Body() dto: CreateUserReqDto) {
+    return this.userService.create(dto); // Service 내부에서 검증
+}
+```
+
+### 4. 빈 catch 블록 금지
+
+```typescript
+// ❌ 금지 — 에러 무시
+try {
+    await this.userRepository.save(user);
+} catch (e) {}
+
+// ✅ 올바른 사용 — 적절한 에러 처리 또는 재throw
+try {
+    await this.userRepository.save(user);
+} catch (error) {
+    this.logger.error('사용자 저장 실패', error);
+    throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+}
+```
+
+## GlobalExceptionFilter 동작 방식
+
+1. **모든 예외 캐치**: `@Catch()` 데코레이터로 처리되지 않은 모든 예외를 잡음
+2. **BusinessException**: `ErrorCode`, `reason`, `details`를 응답에 포함
+3. **기타 HttpException**: 가능한 에러 정보를 추출하여 응답
+4. **시스템 에러 (Non-HttpException)**: `INTERNAL_SERVER_ERROR`로 래핑
+5. **Sentry 연동**: HTTP 500 이상 에러는 자동으로 Sentry에 전송
+6. **로깅**: 4xx는 `warn`, 5xx 및 시스템 에러는 `error` 레벨로 기록


### PR DESCRIPTION
## Summary

`ARCHITECTURE.md`, `DOMAIN_STRATEGY.md`에 정의된 아키텍처 규칙을 AI 어시스턴트 컨텍스트 및 코드 스타일 가이드에 반영합니다.

## Changes

### `CLAUDE.md`
- 문서 경로 테이블에 `DOMAIN_STRATEGY.md` 추가
- 계층 구조 및 의존성 규칙 (섹션 5) 추가
- Facade vs Service 역할 및 호출 규칙 (섹션 6) 추가 (코드 예시 포함)
- 도메인 구조 테이블 설명 상세화 (`DOMAIN_STRATEGY.md` 기준으로 통일)
- 이슈/PR 템플릿 및 Git 컨벤션 강제 규칙 추가

### `docs/development/CODE_STYLE.md`
- Facade / Service 작성 규칙 섹션 추가 (Orchestrator vs Worker 패턴, 올바른/잘못된 예시)
- 비즈니스 규칙 배치 가이드 추가 (엔티티 파일에 상수 정의)
- 계층 간 의존성 규칙 섹션 추가 (허용/금지 방향 + 코드 예시)

### `.gemini/styleguide.md`
- 아키텍처 규칙 리뷰 항목 섹션 추가 (우선순위 높음 4항목 + 중간 3항목)
- 허용되는 의존성 흐름 및 호출 규칙 표 추가
- 예외 처리 항목을 `BusinessException` + `ErrorCode` 사용으로 명확화

## Type of Change

- [x] Documentation (문서 변경)

## Target Environment

- [x] Dev (`dev`)

## Related Issues

- Closes #59

## Testing

- [x] 문서 변경만 포함 (코드 변경 없음)

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint`)
- [ ] (API 변경 시) Swagger 문서가 업데이트되었습니다 — N/A
- [ ] (필요 시) 테스트 코드를 작성했습니다 — N/A

## Screenshots (Optional)

N/A (문서 변경만 포함)

## Additional Notes

PR #49에서 효인이 리뷰 시 지적된 아키텍처 규칙들이 AI 어시스턴트 컨텍스트에 누락되어 있어, 동일한 리뷰가 반복되는 것을 방지하기 위한 작업입니다.