### PR TITLE
Feat: 티켓 상품 목록 조회 API 구현 (#81)

### DIFF
--- a/src/modules/ticket/application/dtos/ticket-product.dto.ts
+++ b/src/modules/ticket/application/dtos/ticket-product.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { TicketType } from '../../domain/enums/ticket-type.enum';
+import { TicketProduct } from '../../domain/entities/ticket-product.entity';
+
+export class TicketProductResDTO {
+    @ApiProperty({ example: 1 })
+    id: number;
+
+    @ApiProperty({ enum: TicketType, example: TicketType.EXPERIENCE })
+    type: TicketType;
+
+    @ApiProperty({ example: 3, description: '이용권 수량 (1/3/5회권)' })
+    quantity: number;
+
+    @ApiProperty({ example: 8900, description: '판매가 (원)' })
+    price: number;
+
+    @ApiProperty({
+        example: 12000,
+        description: '정가 (원)',
+        nullable: true,
+    })
+    originalPrice: number | null;
+
+    @ApiProperty({
+        example: 26,
+        description: '할인율 (%). originalPrice가 없으면 0',
+    })
+    discountRate: number;
+
+    @ApiProperty({ example: true })
+    isActive: boolean;
+
+    @ApiProperty({ example: 1, description: '노출 순서 (오름차순)' })
+    displayOrder: number;
+
+    static from(entity: TicketProduct): TicketProductResDTO {
+        const dto = new TicketProductResDTO();
+        dto.id = entity.id;
+        dto.type = entity.type;
+        dto.quantity = entity.quantity;
+        dto.price = entity.price;
+        dto.originalPrice = entity.originalPrice ?? null;
+        dto.discountRate = TicketProductResDTO.calculateDiscountRate(
+            entity.originalPrice,
+            entity.price
+        );
+        dto.isActive = entity.isActive;
+        dto.displayOrder = entity.displayOrder;
+        return dto;
+    }
+
+    private static calculateDiscountRate(
+        originalPrice: number | undefined | null,
+        price: number
+    ): number {
+        if (!originalPrice || originalPrice <= price) {
+            return 0;
+        }
+        return Math.round(((originalPrice - price) / originalPrice) * 100);
+    }
+}

--- a/src/modules/ticket/application/services/ticket-product.service.ts
+++ b/src/modules/ticket/application/services/ticket-product.service.ts
@@ -3,6 +3,7 @@ import { TicketProductRepository } from '../../infrastructure/repositories/ticke
 import { TicketProduct } from '../../domain/entities/ticket-product.entity';
 import { BusinessException } from 'src/common/exceptions/business.exception';
 import { ErrorCode } from 'src/common/exceptions/error-code.enum';
+import { TicketProductResDTO } from '../dtos/ticket-product.dto';
 
 @Injectable()
 export class TicketProductService {
@@ -14,5 +15,10 @@ export class TicketProductService {
             throw new BusinessException(ErrorCode.TICKET_PRODUCT_NOT_FOUND);
         }
         return ticketProduct;
+    }
+
+    async findActiveProducts(): Promise<TicketProductResDTO[]> {
+        const products = await this.ticketProductRepository.findActiveOrderByDisplayOrder();
+        return products.map((product) => TicketProductResDTO.from(product));
     }
 }

--- a/src/modules/ticket/infrastructure/repositories/ticket-product.repository.ts
+++ b/src/modules/ticket/infrastructure/repositories/ticket-product.repository.ts
@@ -21,4 +21,11 @@ export class TicketProductRepository {
     async existsById(id: number): Promise<boolean> {
         return this.ticketProductRepository.exists({ where: { id } });
     }
+
+    async findActiveOrderByDisplayOrder(): Promise<TicketProduct[]> {
+        return this.ticketProductRepository.find({
+            where: { isActive: true },
+            order: { displayOrder: 'ASC' },
+        });
+    }
 }

--- a/src/modules/ticket/presentation/ticket.controller.ts
+++ b/src/modules/ticket/presentation/ticket.controller.ts
@@ -1,13 +1,24 @@
-import { Controller } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
-import { TicketService } from '../application/services/ticket.service';
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Public } from 'src/common/decorators/public.decorator';
+import { ApiCommonResponseArray } from 'src/common/decorators/swagger.decorator';
+import { TicketProductResDTO } from '../application/dtos/ticket-product.dto';
 import { TicketProductService } from '../application/services/ticket-product.service';
 
 @ApiTags('Ticket')
-@Controller('tickets')
+@Controller('ticket-products')
 export class TicketController {
-    constructor(
-        private readonly ticketService: TicketService,
-        private readonly ticketProductService: TicketProductService
-    ) {}
+    constructor(private readonly ticketProductService: TicketProductService) {}
+
+    @Get()
+    @Public()
+    @ApiOperation({
+        summary: '이용권 상품 목록 조회',
+        description:
+            '활성화된 이용권 상품 목록을 displayOrder 기준 오름차순으로 조회합니다. 할인율(discountRate)은 정가 대비 판매가로 계산됩니다.',
+    })
+    @ApiCommonResponseArray(TicketProductResDTO)
+    async getTicketProducts(): Promise<TicketProductResDTO[]> {
+        return this.ticketProductService.findActiveProducts();
+    }
 }


### PR DESCRIPTION
## Summary

티켓 상품 목록 조회 API를 추가해 활성화된 티켓 상품 리스트를 조회할 수 있도록 구현했습니다.

## Changes

- `GET /ticket-products` 엔드포인트 추가
- 티켓 상품 응답 DTO 신규 추가
- Service에서 엔티티-DTO 매핑 로직 보강
- Repository 목록 조회 메서드 개선 및 컨트롤러 응답 스펙 반영

## Type of Change

해당하는 항목에 체크해주세요:

- [ ] Bug fix (기존 기능을 수정하는 변경)
- [x] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [ ] Documentation (문서 변경)
- [ ] Chore (빌드, 설정 등)

## Target Environment

배포 대상 브랜치를 선택해주세요:

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

관련 이슈를 연결해주세요:

- Closes #81

## Testing

테스트 방법을 작성해주세요:

- [ ] Postman/Swagger로 API 호출 확인
- [ ] 단위 테스트 통과
- [ ] E2E 테스트 통과
- `pnpm run lint` 통과
- `pnpm run build` 통과
- `pnpm exec jest --passWithNoTests` 통과

## Checklist

PR 생성 전 확인사항:

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint`)
- [ ] (API 변경 시) Swagger 문서가 업데이트되었습니다
- [ ] (필요 시) 테스트 코드를 작성했습니다

## Screenshots (Optional)

N/A

## Additional Notes

비활성 상품 제외 및 응답 포맷 일관성을 유지했습니다.