### PR TITLE
Fix: dev 배포 부팅 실패 수정 (#104)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,13 +5,11 @@ import { AppModule } from './app.module';
 import { setupSwagger } from './config/swagger.config';
 import { initializeTransactionalContext } from 'typeorm-transactional';
 import cookieParser from 'cookie-parser';
-import express from 'express';
 
 async function bootstrap() {
     initializeTransactionalContext();
     const app = await NestFactory.create(AppModule);
     app.use(cookieParser());
-    app.use(express.urlencoded({ extended: true }));
 
     app.useGlobalPipes(
         new ValidationPipe({

--- a/src/modules/auth/infrastructure/strategies/jwt-refresh.strategy.ts
+++ b/src/modules/auth/infrastructure/strategies/jwt-refresh.strategy.ts
@@ -3,7 +3,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtPayload } from '../../domain/types/jwt-payload.type';
-import { Request } from 'express';
+import type { Request } from 'express';
 
 @Injectable()
 export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {


### PR DESCRIPTION
## Summary

dev 배포(Lightsail)에서 서버 컨테이너가 `Cannot find module 'express'`로 부팅 실패하던 문제를 해결했습니다.

## Changes

- `src/main.ts`에서 `express` 런타임 import 및 `express.urlencoded()` 사용을 제거
- Auth refresh 전략에서 `Request` import를 type-only로 변경해 런타임 의존을 제거

## Type of Change

- [x] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [ ] Documentation (문서 변경)
- [ ] Chore (빌드, 설정 등)

## Target Environment

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

- Closes #104

## Testing

- [x] 로컬에서 빌드 성공 (`pnpm run build`)
- [x] 로컬에서 린트 통과 (`pnpm run lint`)
- [x] 테스트 실행 (`pnpm run test --passWithNoTests`)

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint`)
- [ ] (API 변경 시) Swagger 문서가 업데이트되었습니다
- [ ] (필요 시) 테스트 코드를 작성했습니다

## Screenshots (Optional)

N/A

## Additional Notes

NestJS는 `@nestjs/platform-express` 기반에서 기본 body parser가 동작하므로, webhook용 `urlencoded` 파싱을 위해 `express`를 직접 import할 필요가 없습니다.