### PR TITLE
Fix: OpenAPI 스키마에 CreateExperienceReqDTO.name 필드 누락 수정 (#101)

### DIFF
--- a/src/modules/experience/application/dtos/experience.dto.ts
+++ b/src/modules/experience/application/dtos/experience.dto.ts
@@ -10,6 +10,7 @@ export class CreateExperienceReqDTO {
     @IsString()
     @MinLength(1)
     @MaxLength(20)
+    @ApiProperty({ example: '마케팅 인턴 경험', minLength: 1, maxLength: 20 })
     name: string;
 
     @IsEnum(JobCategory)


### PR DESCRIPTION
## Summary

`POST /experiences`의 OpenAPI 스키마에서 `name` 필드가 required/properties에 누락되어 Swagger UI 및 클라이언트 코드 생성 시 혼동이 발생하는 버그를 수정합니다.

## Changes

- `CreateExperienceReqDTO`의 `name` 필드에 `@ApiProperty({ example: '마케팅 인턴 경험', minLength: 1, maxLength: 20 })` 데코레이터 추가
- 이로써 `/api-json` 스키마에 `name`이 required + property로 정상 노출됨

## Type of Change

- [x] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [ ] Documentation (문서 변경)
- [ ] Chore (빌드, 설정 등)

## Target Environment

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

- Closes #101

## Testing

- [x] 로컬 빌드 성공 (`pnpm run build` — TSC 0 issues)
- [x] 변경 파일 린트 통과 (`eslint src/modules/experience/**/*.ts`)
- [ ] Swagger UI에서 `POST /experiences` 스키마에 `name` required 확인 (배포 후 검증)

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint` — 변경 파일 기준)
- [x] (API 변경 시) Swagger 문서가 업데이트되었습니다
- [ ] (필요 시) 테스트 코드를 작성했습니다

## Screenshots

N/A

## Additional Notes

`@ApiProperty` 데코레이터 1줄 추가만으로 최소 변경 유지. 기존 class-validator 데코레이터(`@IsString`, `@MinLength`, `@MaxLength`)는 SWC 환경에서 Swagger 플러그인이 자동으로 인식하지 못하므로 명시적 `@ApiProperty`가 필요합니다.