### PR TITLE
Fix: 숫자 path param ParseIntPipe 적용 (#109)

### DIFF
--- a/src/modules/insight/presentation/insight.controller.ts
+++ b/src/modules/insight/presentation/insight.controller.ts
@@ -157,7 +157,7 @@ export class InsightController {
         },
     })
     @ApiCommonErrorResponse(ErrorCode.UNAUTHORIZED, ErrorCode.ACTIVITY_NOT_FOUND)
-    deleteActivityTag(@Param('tagId') tagId: number): string {
+    deleteActivityTag(@Param('tagId', ParseIntPipe) tagId: number): string {
         throw new BusinessException(ErrorCode.NOT_IMPLEMENTED, tagId);
     }
 }

--- a/src/modules/portfolio-correction/presentation/external-portfolio.controller.ts
+++ b/src/modules/portfolio-correction/presentation/external-portfolio.controller.ts
@@ -130,7 +130,7 @@ export class ExternalPortfolioController {
     @ApiCommonResponse(StructuredPortfolioResDTO)
     @ApiCommonErrorResponse(ErrorCode.UNAUTHORIZED, ErrorCode.PORTFOLIO_NOT_FOUND)
     async updateExternalPortfolio(
-        @Param('portfolioId') portfolioId: number,
+        @Param('portfolioId', ParseIntPipe) portfolioId: number,
         @Body() body: UpdatePortfolioBlockReqDTO
     ): Promise<StructuredPortfolioResDTO> {
         return this.externalPortfolioFacade.updateExternalPortfolio(portfolioId, body);
@@ -153,7 +153,9 @@ export class ExternalPortfolioController {
         },
     })
     @ApiCommonErrorResponse(ErrorCode.UNAUTHORIZED, ErrorCode.PORTFOLIO_NOT_FOUND)
-    async deleteExternalPortfolio(@Param('portfolioId') portfolioId: number): Promise<string> {
+    async deleteExternalPortfolio(
+        @Param('portfolioId', ParseIntPipe) portfolioId: number
+    ): Promise<string> {
         await this.externalPortfolioFacade.deleteExternalPortfolio(portfolioId);
         return '포트폴리오가 삭제되었습니다.';
     }

--- a/src/modules/portfolio-correction/presentation/portfolio-correction.controller.ts
+++ b/src/modules/portfolio-correction/presentation/portfolio-correction.controller.ts
@@ -184,7 +184,7 @@ export class PortfolioCorrectionController {
         ErrorCode.CORRECTION_NOT_FOUND,
         ErrorCode.INSUFFICIENT_CREDITS
     )
-    reCreateCompanyInsight(@Param('correctionId') correctionId: number): string {
+    reCreateCompanyInsight(@Param('correctionId', ParseIntPipe) correctionId: number): string {
         throw new BusinessException(ErrorCode.NOT_IMPLEMENTED, correctionId);
     }
 
@@ -200,7 +200,7 @@ export class PortfolioCorrectionController {
         ErrorCode.CORRECTION_BLOCK_LIMIT_EXCEEDED
     )
     mapCorrectionWithPortfolios(
-        @Param('correctionId') correctionId: number,
+        @Param('correctionId', ParseIntPipe) correctionId: number,
         @Body() body: MapCorrectionWithPortfoliosReqDTO
     ): CorrectionItemResDTO[] {
         throw new BusinessException(ErrorCode.NOT_IMPLEMENTED, { correctionId, body });
@@ -222,7 +222,7 @@ export class PortfolioCorrectionController {
         },
     })
     @ApiCommonErrorResponse(ErrorCode.UNAUTHORIZED, ErrorCode.CORRECTION_NOT_FOUND)
-    createCorrectionByAI(@Param('correctionId') correctionId: number): string {
+    createCorrectionByAI(@Param('correctionId', ParseIntPipe) correctionId: number): string {
         throw new BusinessException(ErrorCode.NOT_IMPLEMENTED, correctionId);
     }
 
@@ -248,7 +248,7 @@ export class PortfolioCorrectionController {
     @ApiCommonResponse(CorrectionResDTO)
     @ApiCommonErrorResponse(ErrorCode.UNAUTHORIZED, ErrorCode.CORRECTION_NOT_FOUND)
     updateCorrectionTitle(
-        @Param('correctionId') correctionId: number,
+        @Param('correctionId', ParseIntPipe) correctionId: number,
         @Body() body: UpdateCorrectionTitleReqDTO
     ): CorrectionResDTO {
         throw new BusinessException(ErrorCode.NOT_IMPLEMENTED, { correctionId, body });
@@ -270,7 +270,7 @@ export class PortfolioCorrectionController {
         },
     })
     @ApiCommonErrorResponse(ErrorCode.UNAUTHORIZED, ErrorCode.CORRECTION_NOT_FOUND)
-    deleteCorrection(@Param('correctionId') correctionId: number): string {
+    deleteCorrection(@Param('correctionId', ParseIntPipe) correctionId: number): string {
         throw new BusinessException(ErrorCode.NOT_IMPLEMENTED, correctionId);
     }
 }

--- a/src/modules/portfolio/presentation/portfolio.controller.ts
+++ b/src/modules/portfolio/presentation/portfolio.controller.ts
@@ -38,7 +38,7 @@ export class PortfolioController {
     @ApiCommonResponse(PortfolioDetailResDTO)
     @ApiCommonErrorResponse(ErrorCode.UNAUTHORIZED, ErrorCode.PORTFOLIO_NOT_FOUND)
     updatePortfolio(
-        @Param('portfolioId') portfolioId: number,
+        @Param('portfolioId', ParseIntPipe) portfolioId: number,
         @Body() body: UpdatePortfolioReqDTO
     ): PortfolioDetailResDTO {
         throw new BusinessException(ErrorCode.NOT_IMPLEMENTED, { portfolioId, body });
@@ -60,7 +60,7 @@ export class PortfolioController {
         },
     })
     @ApiCommonErrorResponse(ErrorCode.UNAUTHORIZED, ErrorCode.PORTFOLIO_NOT_FOUND)
-    deletePortfolio(@Param('portfolioId') portfolioId: number): string {
+    deletePortfolio(@Param('portfolioId', ParseIntPipe) portfolioId: number): string {
         throw new BusinessException(ErrorCode.NOT_IMPLEMENTED, portfolioId);
     }
 
@@ -71,7 +71,9 @@ export class PortfolioController {
     })
     @ApiCommonResponse(ExportPortfolioResDTO)
     @ApiCommonErrorResponse(ErrorCode.UNAUTHORIZED, ErrorCode.PORTFOLIO_NOT_FOUND)
-    exportPortfolio(@Param('portfolioId') portfolioId: number): ExportPortfolioResDTO {
+    exportPortfolio(
+        @Param('portfolioId', ParseIntPipe) portfolioId: number
+    ): ExportPortfolioResDTO {
         throw new BusinessException(ErrorCode.NOT_IMPLEMENTED, portfolioId);
     }
 }


### PR DESCRIPTION
## Summary

숫자 path param을 `number`로 선언했지만 ParseIntPipe가 누락된 엔드포인트들에 대해, 런타임 타입 불일치(string 전달) 문제를 방지하도록 `ParseIntPipe`를 적용했습니다.

## Changes

- `portfolioId`, `correctionId`, `tagId` 등 숫자 path param에 `ParseIntPipe` 적용
- 적용 대상: portfolio / portfolio-correction / external-portfolio / insight 컨트롤러

## Type of Change

해당하는 항목에 체크해주세요:

- [x] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [ ] Documentation (문서 변경)
- [ ] Chore (빌드, 설정 등)

## Target Environment

배포 대상 브랜치를 선택해주세요:

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

관련 이슈를 연결해주세요:

- Closes #109

## Testing

테스트 방법을 작성해주세요:

- [ ] Postman/Swagger로 API 호출 확인
- [ ] 단위 테스트 통과
- [ ] E2E 테스트 통과

로컬에서 `pnpm run lint`, `pnpm run build` 확인했습니다.

## Checklist

PR 생성 전 확인사항:

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint`)
- [ ] (API 변경 시) Swagger 문서가 업데이트되었습니다
- [ ] (필요 시) 테스트 코드를 작성했습니다

## Screenshots (Optional)

N/A

## Additional Notes

- route param은 Pipe가 없으면 런타임에서 string이므로, 숫자 ID는 `ParseIntPipe`로 일관되게 변환/검증하도록 맞췄습니다.