### PR TITLE
Fix: 포트폴리오 첨삭 조회 쿼리 SnakeNamingStrategy 호환성 수정 (#141)

### DIFF
--- a/src/modules/portfolio-correction/infrastructure/repositories/correction-item.repository.ts
+++ b/src/modules/portfolio-correction/infrastructure/repositories/correction-item.repository.ts
@@ -17,8 +17,8 @@ export class CorrectionItemRepository {
     async findPortfolioIdsByCorrectionId(correctionId: number): Promise<number[]> {
         const results = await this.correctionItemRepository
             .createQueryBuilder('ci')
-            .select('ci.portfolioId', 'portfolioId')
-            .where('ci.portfolioCorrectionId = :correctionId', { correctionId })
+            .select('ci.portfolio', 'portfolioId')
+            .where('ci.portfolioCorrection = :correctionId', { correctionId })
             .getRawMany<{ portfolioId: number }>();
         return results.map((r) => r.portfolioId);
     }

--- a/src/modules/portfolio-correction/infrastructure/repositories/portfolio-correction.repository.ts
+++ b/src/modules/portfolio-correction/infrastructure/repositories/portfolio-correction.repository.ts
@@ -48,7 +48,7 @@ export class PortfolioCorrectionRepository {
     ): Promise<PortfolioCorrection[]> {
         const qb = this.portfolioCorrectionRepository
             .createQueryBuilder('pc')
-            .where('pc.userId = :userId', { userId })
+            .where('pc.user = :userId', { userId })
             .orderBy('pc.createdAt', 'DESC');
 
         const trimmedKeyword = keyword?.trim();


### PR DESCRIPTION
## Summary
- GET /portfolio-corrections 엔드포인트에서 쿼리 빌더의 컬럼명이 camelCase로 작성되어 SnakeNamingStrategy와 호환되지 않아 500 에러 발생
- 쿼리 빌더에서 관계 기반 where 절로 변경하여 자동 컬럼명 변환 적용

## Changes
- `portfolio-correction.repository.ts`: `pc.userId` → `pc.user` (관계 기반 쿼리)
- `correction-item.repository.ts`: `ci.portfolioId`, `ci.portfolioCorrectionId` → 관계 기반 쿼리로 변경

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Target Environment
- Dev

## Related Issues
- Closes #141

## Testing
- [x] Build passes (`pnpm run build`)
- [x] Lint passes (`pnpm run lint`)
- [x] No type errors

## Checklist
- [x] Code follows style guidelines
- [x] No new warnings generated
- [x] Changes are minimal and focused on the bug fix
- [x] No architecture violations (repository doesn't throw, service throws)

## Screenshots
N/A

## Additional Notes
- SnakeNamingStrategy 도입 후 쿼리 빌더에서 컬럼명을 직접 참조할 때는 snake_case를 사용하거나 관계 기반 쿼리를 사용해야 함
- 이 변경으로 자동 컬럼명 변환이 적용되어 호환성 문제 해결