### PR TITLE
Chore: dev seed 서비스 확장 — 로깅·에러 핸들링·검증 문서 (#122)

### DIFF
--- a/docs/development/DEV_SEED.md
+++ b/docs/development/DEV_SEED.md
@@ -5,18 +5,39 @@ In `local`/`dev` profiles, TypeORM runs with `synchronize: true` (see `src/confi
 
 To avoid empty dev databases blocking manual tests and smoke tests, we seed minimal reference data on app startup.
 
-## ticket_product (dev/local)
+## Safety guard
+
+All seed logic is gated by `APP_PROFILE`:
+
+| APP_PROFILE | Seed runs? |
+| ----------- | ---------- |
+| `local`     | Yes        |
+| `dev`       | Yes        |
+| `prod`      | **No**     |
+| (unset)     | **No**     |
+
+If the profile is not `local` or `dev`, the seed service returns immediately without any DB access.
+
+## ticket_product
 
 Seed service:
 
 - `src/modules/ticket/application/services/ticket-product-seed.service.ts`
 
-Behavior:
+Lifecycle:
 
-- Runs only when `APP_PROFILE` is `local` or `dev`
-- Ensures the following 6 products exist (match by `(type, quantity)`) and updates fields if mismatched
+- Implements `OnModuleInit` — runs automatically on every server start
+- No manual invocation required
 
-Seed values:
+Idempotent logic:
+
+- Match key: `(type, quantity)`
+- Row missing → INSERT
+- Row exists but fields differ (price, originalPrice, displayOrder, isActive) → UPDATE
+- Row exists and matches → SKIP (no write)
+- Seed failure is caught and logged as `error`; it never prevents server startup
+
+Seed values (6 products):
 
 | type                 | quantity | price | originalPrice | displayOrder |
 | -------------------- | -------- | ----- | ------------- | ------------ |
@@ -26,3 +47,49 @@ Seed values:
 | PORTFOLIO_CORRECTION | 1        | 990   | null          | 4            |
 | PORTFOLIO_CORRECTION | 3        | 2700  | 2970          | 5            |
 | PORTFOLIO_CORRECTION | 5        | 4100  | 4950          | 6            |
+
+## Verifying seed data
+
+### 1. Server logs
+
+On startup the seed service emits one of these log lines (class: `TicketProductSeedService`):
+
+```
+[seed] ticket_product OK — 6종 모두 최신 (변경 없음)
+[seed] ticket_product 완료 — 생성 N, 갱신 M, 스킵 K (전체 6종)
+[seed] ticket_product seed 실패 — <error message>
+```
+
+### 2. Public API
+
+`GET /ticket-products` is a public endpoint (no auth required):
+
+```bash
+# Local
+curl -s http://localhost:3000/ticket-products | jq '.result | length'
+# Expected: 6
+
+# Dev server
+curl -s https://folioo-dev-api.log8.kr/ticket-products | jq '.result | length'
+# Expected: 6
+```
+
+### 3. Smoke test preflight
+
+`scripts/smoke-dev-api.mjs` performs a preflight `GET /ticket-products` to discover `ticketProductId`.
+If the seed ran correctly, preflight succeeds and subsequent `POST /payments` uses a real product ID.
+
+## After a DB reset
+
+If the dev database is wiped (see `docs/development/DEV_DB_RESET.md`), simply restart the server.
+TypeORM `synchronize: true` recreates tables, and the seed service re-inserts all 6 products on the next startup.
+
+```bash
+# 1. Reset DB (deletes all data)
+docker compose --env-file .env.dev -f docker-compose.dev.yml down -v
+docker compose --env-file .env.dev -f docker-compose.dev.yml up -d --force-recreate --wait
+
+# 2. Server restart triggers seed automatically
+# 3. Verify
+curl -s https://folioo-dev-api.log8.kr/ticket-products | jq '.result | length'
+```

--- a/src/modules/ticket/application/services/ticket-product-seed.service.ts
+++ b/src/modules/ticket/application/services/ticket-product-seed.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { TicketProduct } from '../../domain/entities/ticket-product.entity';
 import { TicketType } from '../../domain/enums/ticket-type.enum';
@@ -12,8 +12,28 @@ type SeedTicketProduct = {
     displayOrder: number;
 };
 
+type SeedResult = {
+    total: number;
+    created: number;
+    updated: number;
+    skipped: number;
+};
+
+/**
+ * Dev/local 환경 전용 ticket_product 시드 서비스.
+ *
+ * 서버 기동 시 `OnModuleInit` 훅으로 자동 실행되며,
+ * EXPERIENCE / PORTFOLIO_CORRECTION x 1·3·5회권 총 6종의
+ * 상품 데이터를 idempotent(upsert) 하게 보장합니다.
+ *
+ * - 매칭 키: `(type, quantity)`
+ * - 없으면 INSERT, 필드가 다르면 UPDATE, 동일하면 SKIP
+ * - `APP_PROFILE`이 `local` 또는 `dev`가 아니면 아무 작업도 하지 않음
+ */
 @Injectable()
 export class TicketProductSeedService implements OnModuleInit {
+    private readonly logger = new Logger(TicketProductSeedService.name);
+
     constructor(
         private readonly configService: ConfigService,
         private readonly ticketProductRepository: TicketProductRepository
@@ -26,14 +46,33 @@ export class TicketProductSeedService implements OnModuleInit {
     private async ensureDevSeed(): Promise<void> {
         const profile = this.configService.get<string>('APP_PROFILE');
         const isDevLike = profile === 'local' || profile === 'dev';
+
         if (!isDevLike) {
             return;
         }
 
+        this.logger.log(`[seed] profile="${profile}" — ticket_product seed 시작`);
+
+        try {
+            const result = await this.reconcile();
+            this.logSummary(result);
+        } catch (error) {
+            // 시드 실패가 서버 기동을 막아서는 안 된다
+            this.logger.error(
+                `[seed] ticket_product seed 실패 — ${error instanceof Error ? error.message : String(error)}`,
+                error instanceof Error ? error.stack : undefined
+            );
+        }
+    }
+
+    private async reconcile(): Promise<SeedResult> {
         const expected = TicketProductSeedService.getExpectedProducts();
         const existing = await this.ticketProductRepository.findAll();
 
         const toSave: TicketProduct[] = [];
+        let created = 0;
+        let updated = 0;
+        let skipped = 0;
 
         for (const item of expected) {
             const found = existing.find(
@@ -41,14 +80,15 @@ export class TicketProductSeedService implements OnModuleInit {
             );
 
             if (!found) {
-                const created = new TicketProduct();
-                created.type = item.type;
-                created.quantity = item.quantity;
-                created.price = item.price;
-                created.originalPrice = item.originalPrice;
-                created.displayOrder = item.displayOrder;
-                created.isActive = true;
-                toSave.push(created);
+                const entity = new TicketProduct();
+                entity.type = item.type;
+                entity.quantity = item.quantity;
+                entity.price = item.price;
+                entity.originalPrice = item.originalPrice;
+                entity.displayOrder = item.displayOrder;
+                entity.isActive = true;
+                toSave.push(entity);
+                created++;
                 continue;
             }
 
@@ -59,6 +99,7 @@ export class TicketProductSeedService implements OnModuleInit {
                 found.isActive !== true;
 
             if (!needsUpdate) {
+                skipped++;
                 continue;
             }
 
@@ -67,16 +108,32 @@ export class TicketProductSeedService implements OnModuleInit {
             found.displayOrder = item.displayOrder;
             found.isActive = true;
             toSave.push(found);
+            updated++;
         }
 
-        if (toSave.length === 0) {
+        if (toSave.length > 0) {
+            await this.ticketProductRepository.saveAll(toSave);
+        }
+
+        return { total: expected.length, created, updated, skipped };
+    }
+
+    private logSummary(result: SeedResult): void {
+        const { total, created, updated, skipped } = result;
+
+        if (created === 0 && updated === 0) {
+            this.logger.log(`[seed] ticket_product OK — ${total}종 모두 최신 (변경 없음)`);
             return;
         }
 
-        await this.ticketProductRepository.saveAll(toSave);
+        const parts: string[] = [];
+        if (created > 0) parts.push(`생성 ${created}`);
+        if (updated > 0) parts.push(`갱신 ${updated}`);
+        if (skipped > 0) parts.push(`스킵 ${skipped}`);
+        this.logger.log(`[seed] ticket_product 완료 — ${parts.join(', ')} (전체 ${total}종)`);
     }
 
-    private static getExpectedProducts(): SeedTicketProduct[] {
+    static getExpectedProducts(): SeedTicketProduct[] {
         const basePrice = 990;
 
         const mk = (
@@ -93,14 +150,13 @@ export class TicketProductSeedService implements OnModuleInit {
             displayOrder,
         });
 
-        const exp1 = mk(TicketType.EXPERIENCE, 1, basePrice, null, 1);
-        const exp3 = mk(TicketType.EXPERIENCE, 3, 2700, basePrice * 3, 2);
-        const exp5 = mk(TicketType.EXPERIENCE, 5, 4100, basePrice * 5, 3);
-
-        const corr1 = mk(TicketType.PORTFOLIO_CORRECTION, 1, basePrice, null, 4);
-        const corr3 = mk(TicketType.PORTFOLIO_CORRECTION, 3, 2700, basePrice * 3, 5);
-        const corr5 = mk(TicketType.PORTFOLIO_CORRECTION, 5, 4100, basePrice * 5, 6);
-
-        return [exp1, exp3, exp5, corr1, corr3, corr5];
+        return [
+            mk(TicketType.EXPERIENCE, 1, basePrice, null, 1),
+            mk(TicketType.EXPERIENCE, 3, 2700, basePrice * 3, 2),
+            mk(TicketType.EXPERIENCE, 5, 4100, basePrice * 5, 3),
+            mk(TicketType.PORTFOLIO_CORRECTION, 1, basePrice, null, 4),
+            mk(TicketType.PORTFOLIO_CORRECTION, 3, 2700, basePrice * 3, 5),
+            mk(TicketType.PORTFOLIO_CORRECTION, 5, 4100, basePrice * 5, 6),
+        ];
     }
 }


### PR DESCRIPTION
## Summary

dev 환경 ticket_product 시드 서비스에 Logger 기반 관찰성과 에러 핸들링을 추가하고, 시드 실행·검증 방법을 문서화하여 DB 리셋 후 스모크 테스트 안정성을 확보합니다.

## Changes

- `TicketProductSeedService`에 NestJS Logger 추가 (시작·완료·실패 로그)
- 시드 실패 시 서버 기동을 차단하지 않도록 try/catch 에러 핸들링
- reconcile 결과를 created/updated/skipped 카운트로 분리하여 서머리 로그 출력
- `getExpectedProducts()`를 `static`으로 유지하되 반환값을 인라인 배열로 정리
- `docs/development/DEV_SEED.md` 확장: safety guard 설명, 검증 방법 3가지 (로그·API·smoke preflight), DB 리셋 후 복구 절차

## Type of Change

- [ ] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [ ] Documentation (문서 변경)
- [x] Chore (빌드, 설정 등)

## Target Environment

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

- Closes #122

## Testing

- [x] `pnpm run build` 성공 (0 issues)
- [x] `pnpm run lint` 통과 (기존 metadata.ts 이슈 외 신규 없음)
- [ ] dev 서버 배포 후 로그에서 `[TicketProductSeedService] [seed] ticket_product OK` 확인
- [ ] `curl https://folioo-dev-api.log8.kr/ticket-products | jq '.result | length'` → 6

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint`)
- [ ] (API 변경 시) Swagger 문서가 업데이트되었습니다
- [ ] (필요 시) 테스트 코드를 작성했습니다

## Screenshots (Optional)

N/A

## Additional Notes

- 기존 6종 시드 데이터(EXPERIENCE/PORTFOLIO_CORRECTION × 1·3·5)는 변경 없음
- 동작 로직 변경 없음 — Logger와 에러 핸들링 래핑만 추가
- `metadata.ts` lint 에러는 prebuild 스크립트가 매번 덮어쓰는 자동 생성 파일로, 기존 이슈입니다