### PR TITLE
Chore: 스모크 테스트 payload override 확장 및 리포트 출력 개선 (#103)

### DIFF
--- a/scripts/smoke-dev-api.mjs
+++ b/scripts/smoke-dev-api.mjs
@@ -486,10 +486,10 @@ function payloadOverrides(method, rawPath, ctx) {
     }
     // Auth SMS endpoints (NOT_IMPLEMENTED - min-valid payloads to expose 501)
     if (method === 'POST' && rawPath === '/auth/sms/send') {
-        return { phoneNumber: '01000000000' };
+        return { phoneNum: '01000000000' };
     }
     if (method === 'POST' && rawPath === '/auth/sms/verify') {
-        return { phoneNumber: '01000000000', code: '000000' };
+        return { phoneNum: '01000000000', verifyToken: '000000' };
     }
     // Auth management endpoints (NOT_IMPLEMENTED - empty body to expose 501)
     if (method === 'POST' && rawPath === '/auth/logout') {


### PR DESCRIPTION
## Summary

PR #146에서 도입된 스모크 테스트 v2의 후속 개선입니다.
NOT_IMPLEMENTED(501) 엔드포인트의 400 마스킹을 줄이기 위해 payload override를 확장하고, 콘솔 출력을 분류별 요약 형태로 개선합니다.

## Changes

- **Payload override 확장**: `POST /auth/sms/send`, `POST /auth/sms/verify`에 최소 유효 payload 추가 (400 → 501 노출)
- **Auth 관리 엔드포인트 override**: `POST /auth/logout`, `POST /auth/{kakao,google,naver}/unlink`에 빈 body override 추가
- **콘솔 출력 개선**: JSON dump 대신 분류별 요약(Classification) + HTTP 버킷 형태의 human-readable 출력
- **Machine-parseable 하위 호환**: 마지막 줄에 JSON 한 줄 출력 유지 (`{ outPath, buckets, classification, count }`)

## Type of Change

- [ ] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [ ] Documentation (문서 변경)
- [x] Chore (빌드, 설정 등)

## Target Environment

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

- Closes #103

## Testing

- [x] `node --check scripts/smoke-dev-api.mjs` 문법 검증 통과
- [x] `node scripts/smoke-dev-api.mjs --help` 정상 출력 확인
- [x] `pnpm run lint` 통과
- [x] `pnpm run build` 통과
- [ ] dev 서버 대상 실행 (`FOLIOO_ACCESS_TOKEN=... node scripts/smoke-dev-api.mjs --mutate`)

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint`)
- [ ] (API 변경 시) Swagger 문서가 업데이트되었습니다
- [ ] (필요 시) 테스트 코드를 작성했습니다

## Screenshots (Optional)

N/A

## Additional Notes

- 이 PR은 #146(스모크 v2 도입)의 후속 개선입니다
- 기존 CLI 옵션(`--mutate`, `--include`, `--exclude` 등)은 모두 하위 호환됩니다
- 콘솔 마지막 줄 JSON 포맷이 변경되었습니다: `classBuckets` → `classification` (키 이름만 변경, 구조 동일)