### PR TITLE
Fix: localhost FE 카카오 로그인 refresh 쿠키 전달 복구 (#168)

### DIFF
--- a/src/modules/auth/presentation/auth.controller.ts
+++ b/src/modules/auth/presentation/auth.controller.ts
@@ -82,7 +82,6 @@ export class AuthController {
             sameSite: isLocal ? 'lax' : 'none',
             path: '/',
             maxAge: TimeUtil.toMs(expiresIn),
-            partitioned: true,
         });
         const clientUrl = this.configService.getOrThrow<string>('CLIENT_REDIRECT_URI');
         res.redirect(`${clientUrl}?status=success`);


### PR DESCRIPTION
## Summary

localhost:3000에서 dev API로 카카오 로그인 후 /auth/refresh 호출 시 refreshToken 쿠키가 누락되어 AUTH4012가 발생하던 문제를 수정했습니다.

## Changes

- auth 콜백에서 설정하던 refreshToken 쿠키 옵션 중 partitioned 값을 제거
- localhost(top-level site) + dev API(cross-site) 테스트 시 refreshToken 쿠키 전달 경로를 단순화

## Type of Change

해당하는 항목에 체크해주세요:

- [x] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [ ] Documentation (문서 변경)
- [ ] Chore (빌드, 설정 등)

## Target Environment

배포 대상 브랜치를 선택해주세요:

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

관련 이슈를 연결해주세요:

- Closes #168

## Testing

테스트 방법을 작성해주세요:

- [ ] Postman/Swagger로 API 호출 확인
- [ ] 단위 테스트 통과
- [ ] E2E 테스트 통과

## Checklist

PR 생성 전 확인사항:

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [ ] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [ ] 로컬에서 린트가 통과합니다 (`pnpm run lint`)
- [ ] (API 변경 시) Swagger 문서가 업데이트되었습니다
- [ ] (필요 시) 테스트 코드를 작성했습니다

## Screenshots (Optional)

N/A

## Additional Notes

- `pnpm run build`는 본 변경과 무관한 기존 이슈(`src/modules/embedding/strategies/open-router.strategy.ts`에서 `openai` 모듈 타입 해석 실패, TS2307)로 실패합니다.
- pre-commit 훅에서 변경 파일 대상 `eslint --fix`, `prettier --write`는 정상 수행되었습니다.