### PR TITLE
Fix: 이벤트 nullable 컬럼 타입 명시로 배포 오류 방지 (#175)

### DIFF
--- a/src/modules/event/domain/entities/event-feedback-submission.entity.ts
+++ b/src/modules/event/domain/entities/event-feedback-submission.entity.ts
@@ -22,7 +22,7 @@ export class EventFeedbackSubmission extends BaseEntity {
     @JoinColumn({ name: 'user_id' })
     user: User;
 
-    @Column({ name: 'user_id', nullable: true })
+    @Column({ name: 'user_id', type: 'int', nullable: true })
     userId: number | null;
 
     @Column({ name: 'phone_num', length: 20 })
@@ -35,7 +35,7 @@ export class EventFeedbackSubmission extends BaseEntity {
     })
     source: EventFeedbackSource;
 
-    @Column({ name: 'external_submission_id', length: 100, nullable: true })
+    @Column({ name: 'external_submission_id', type: 'varchar', length: 100, nullable: true })
     externalSubmissionId: string | null;
 
     @Column({
@@ -46,15 +46,15 @@ export class EventFeedbackSubmission extends BaseEntity {
     })
     reviewStatus: EventFeedbackReviewStatus;
 
-    @Column({ name: 'reviewed_by', nullable: true, length: 64 })
+    @Column({ name: 'reviewed_by', type: 'varchar', nullable: true, length: 64 })
     reviewedBy: string | null;
 
-    @Column({ name: 'reviewed_at', nullable: true })
+    @Column({ name: 'reviewed_at', type: 'timestamp', nullable: true })
     reviewedAt: Date | null;
 
-    @Column({ name: 'review_note', nullable: true, length: 500 })
+    @Column({ name: 'review_note', type: 'varchar', nullable: true, length: 500 })
     reviewNote: string | null;
 
-    @Column({ name: 'rewarded_participation_id', nullable: true })
+    @Column({ name: 'rewarded_participation_id', type: 'int', nullable: true })
     rewardedParticipationId: number | null;
 }

--- a/src/modules/event/domain/entities/event-participation.entity.ts
+++ b/src/modules/event/domain/entities/event-participation.entity.ts
@@ -45,9 +45,9 @@ export class EventParticipation extends BaseEntity {
     })
     rewardStatus: EventRewardStatus;
 
-    @Column({ nullable: true, length: 64 })
+    @Column({ type: 'varchar', nullable: true, length: 64 })
     grantedBy: string | null;
 
-    @Column({ nullable: true, length: 500 })
+    @Column({ type: 'varchar', nullable: true, length: 500 })
     grantReason: string | null;
 }


### PR DESCRIPTION
## Summary

TypeORM이 nullable union 타입 필드를 `Object`로 해석해 Postgres 초기화 시 `DataTypeNotSupportedError`가 발생하던 문제를 방지하기 위해 이벤트 엔티티의 컬럼 타입을 명시했습니다.

## Changes

- `event_participation`의 nullable string 컬럼(`grantedBy`, `grantReason`)에 `type: 'varchar'` 명시
- `event_feedback_submission`의 nullable 컬럼들(`userId`, `externalSubmissionId`, `reviewedBy`, `reviewedAt`, `reviewNote`, `rewardedParticipationId`)에 명시 타입 추가
- 배포 시점 메타데이터 추론 차이(SWC/reflect-metadata)로 인한 재발 가능성을 줄이도록 타입 선언을 일관화

## Type of Change

해당하는 항목에 체크해주세요:

- [x] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [ ] Documentation (문서 변경)
- [ ] Chore (빌드, 설정 등)

## Target Environment

배포 대상 브랜치를 선택해주세요:

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

관련 이슈를 연결해주세요:

- Closes #175

## Testing

테스트 방법을 작성해주세요:

- [ ] Postman/Swagger로 API 호출 확인
- [ ] 단위 테스트 통과
- [ ] E2E 테스트 통과
- 로컬 빌드 확인: `pnpm run build` (pass)
- 린트 확인: `pnpm run lint` (pass)
- 테스트 스위트가 없는 환경에서 Jest 실행 확인: `pnpm exec jest --passWithNoTests` (pass)

## Checklist

PR 생성 전 확인사항:

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint`)
- [ ] (API 변경 시) Swagger 문서가 업데이트되었습니다
- [ ] (필요 시) 테스트 코드를 작성했습니다

## Screenshots (Optional)

N/A

## Additional Notes

- 본 변경은 스키마 의미 변경 없이 컬럼 타입 명시를 통해 런타임 메타데이터 해석 오류를 방지하는 목적입니다.