### PR TITLE
Docs: 포트폴리오 생성/내보내기 설계 문서 추가 (#184)

### DIFF
--- a/docs/development/PORTFOLIO_CREATE_EXPORT_PLAN_184.md
+++ b/docs/development/PORTFOLIO_CREATE_EXPORT_PLAN_184.md
@@ -1,0 +1,141 @@
+# Portfolio Create And Export Plan (#184)
+
+## Goal
+
+- Define backend API strategy for "텍스트형 포트폴리오 생성" button flow.
+- Decide ownership boundary for PDF export between FE and BE.
+- Provide an implementation checklist that can be executed in small PRs.
+
+## Current State
+
+- `POST /portfolios/{portfolioId}/export` exists but returns `NOT_IMPLEMENTED`.
+- Portfolio module supports:
+    - `GET /portfolios/{portfolioId}`
+    - `PATCH /portfolios/{portfolioId}`
+    - `DELETE /portfolios/{portfolioId}`
+- Experience module has completed conversation state and owns interview session id.
+- Portfolio entity has `sourceType` (`INTERNAL`, `EXTERNAL`) and optional `experience` relation.
+
+## Proposed API For Text Portfolio Creation
+
+### Endpoint
+
+- `POST /portfolios`
+
+### Request (`CreatePortfolioReqDTO`)
+
+- `sourceType: INTERNAL | EXTERNAL`
+- `experienceId?: number`
+- `name?: string` (optional only for `EXTERNAL`)
+
+Validation rules:
+
+- If `sourceType=INTERNAL`, `experienceId` is required.
+- If `sourceType=EXTERNAL`, `experienceId` must be omitted.
+- `INTERNAL` creation must enforce one-to-one with experience (no duplicate portfolio per experience).
+
+### Response (`PortfolioResDTO`)
+
+- `portfolioId`
+- `sourceType`
+- `experienceId` (nullable)
+- `name`, `description`, `responsibilities`, `problemSolving`, `learnings`, `contributionRate`
+
+### Error Handling
+
+- Reuse existing `BusinessException` pattern.
+- Add new error code for duplicate internal mapping:
+    - `PORTFOLIO_ALREADY_EXISTS` (`PORTFOLIO4091`) -> HTTP 409
+- Existing candidates:
+    - `EXPERIENCE_NOT_FOUND`
+    - `PORTFOLIO_NOT_FOUND`
+    - `BAD_REQUEST`
+
+## Layered Architecture Design
+
+- Controller:
+    - Input validation + Swagger contract.
+    - Delegate to Facade/Service only.
+- Facade:
+    - Orchestrate cross-domain flow (`ExperienceService` + `PortfolioService`).
+- Service:
+    - Domain rule checks.
+    - Portfolio creation and persistence.
+- Repository:
+    - Data access only (no throws).
+
+Suggested flow for `sourceType=INTERNAL`:
+
+1. Validate experience ownership by user.
+2. Check existing portfolio bound to same experience.
+3. Build initial portfolio from experience data.
+4. Save and return DTO.
+
+Suggested flow for `sourceType=EXTERNAL`:
+
+1. Create empty or minimally initialized portfolio.
+2. Save with `sourceType=EXTERNAL`.
+3. Return DTO.
+
+## Export Strategy Decision
+
+### Decision
+
+- FE owns PDF generation by default.
+
+### Why
+
+- FE already has rendered data from `GET /portfolios/{portfolioId}`.
+- WYSIWYG consistency is easier in FE rendering context.
+- Avoid BE runtime cost and complexity (headless browser/PDF library infra).
+
+### Backend Responsibility Boundary
+
+- Keep `POST /portfolios/{portfolioId}/export` as compatibility endpoint temporarily.
+- Mark as deprecated in Swagger and docs.
+- Remove endpoint in a follow-up when FE rollout reaches 100%.
+
+### Cases Where BE Export Should Stay
+
+- Regulatory requirement for server-side sealed document generation.
+- Strong audit trail requirement for generated artifacts.
+- Signed URL/file lifecycle requirements that FE cannot satisfy.
+
+## Migration Plan
+
+1. Introduce `POST /portfolios` first.
+2. FE switches button action to call `POST /portfolios`, then render/export locally.
+3. Keep `POST /portfolios/{portfolioId}/export` deprecated but available during transition.
+4. Observe usage metrics and remove deprecated endpoint after stabilization.
+
+## Risk And Mitigation
+
+- Duplicate creation race for same experience:
+    - Mitigate with DB-level uniqueness + service pre-check.
+- FE PDF quality variance by browser:
+    - Mitigate with a fixed FE export library/version and regression snapshots.
+- Backward compatibility break:
+    - Mitigate by phased deprecation window.
+
+## Implementation Checklist
+
+### Backend
+
+- [ ] Add issue for `POST /portfolios` implementation.
+- [ ] Add DTOs (`CreatePortfolioReqDTO`, `PortfolioResDTO`).
+- [ ] Implement controller + facade + service flow.
+- [ ] Add `PORTFOLIO_ALREADY_EXISTS` to error enum/map.
+- [ ] Update `docs/API.md` + Swagger.
+- [ ] Add tests for internal/external creation and duplicate guard.
+
+### Frontend
+
+- [ ] Button action: call `POST /portfolios`.
+- [ ] Use returned portfolio data/id for editing and local PDF export.
+- [ ] Add fallback UX for deprecated export endpoint if needed.
+
+### Rollout
+
+- [ ] Ship to dev.
+- [ ] Validate with smoke + manual scenario.
+- [ ] Create cleanup task to remove deprecated export endpoint.


### PR DESCRIPTION
## Summary
`POST /portfolios` 신설과 FE PDF 내보내기 전환 전략을 정리한 설계 문서를 추가했습니다.

## Changes
- `docs/development/PORTFOLIO_CREATE_EXPORT_PLAN_184.md` 문서를 추가했습니다.
- 생성 API 계약(입출력/검증/에러), 계층 설계, 마이그레이션 단계, 리스크 대응안을 정리했습니다.
- `POST /portfolios/{portfolioId}/export`의 호환 유지/폐기 전략을 포함했습니다.

## Type of Change
해당하는 항목에 체크해주세요:
- [ ] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [x] Documentation (문서 변경)
- [ ] Chore (빌드, 설정 등)

## Target Environment
배포 대상 브랜치를 선택해주세요:
- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues
관련 이슈를 연결해주세요:
- Closes #184

## Testing
테스트 방법을 작성해주세요:
- [ ] Postman/Swagger로 API 호출 확인
- [ ] 단위 테스트 통과
- [ ] E2E 테스트 통과
- [x] 문서 링크/내용 검토

## Checklist
PR 생성 전 확인사항:
- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [ ] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [ ] 로컬에서 린트가 통과합니다 (`pnpm run lint`)
- [ ] (API 변경 시) Swagger 문서가 업데이트되었습니다
- [ ] (필요 시) 테스트 코드를 작성했습니다

## Screenshots (Optional)
N/A

## Additional Notes
문서 PR이므로 코드 변경은 포함하지 않았고, 후속 구현 PR에서 본 문서를 기준으로 API를 단계적으로 반영합니다.