### PR TITLE
Fix: UserAgreement agreeAt 타입 지정으로 dev 배포 실패 수정 (#189)

### DIFF
--- a/src/modules/user/domain/user-agreement.entity.ts
+++ b/src/modules/user/domain/user-agreement.entity.ts
@@ -26,7 +26,7 @@ export class UserAgreement extends BaseEntity {
     @Column({ name: 'is_agree' })
     isAgree: boolean;
 
-    @Column({ name: 'agree_at', nullable: true })
+    @Column({ name: 'agree_at', type: 'timestamptz', nullable: true })
     agreeAt: Date | null;
 
     static createMarketingAgreement(


### PR DESCRIPTION
## Summary
dev 배포 실패 원인이었던 `UserAgreement.agreeAt` 타입 미지정을 수정해 Postgres에서 정상 매핑되도록 반영했습니다.

## Changes
- `UserAgreement` 엔티티의 `agreeAt` 컬럼에 `type: 'timestamptz'`를 명시했습니다.
- `DataTypeNotSupportedError`(`Object` 타입 해석)로 인한 부팅 실패를 제거했습니다.

## Type of Change
해당하는 항목에 체크해주세요:
- [x] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [ ] Documentation (문서 변경)
- [ ] Chore (빌드, 설정 등)

## Target Environment
배포 대상 브랜치를 선택해주세요:
- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues
관련 이슈를 연결해주세요:
- Closes #189

## Testing
테스트 방법을 작성해주세요:
- [ ] Postman/Swagger로 API 호출 확인
- [ ] 단위 테스트 통과
- [ ] E2E 테스트 통과
- 실행 커맨드:
  - `pnpm run build`
  - `pnpm run lint`

## Checklist
PR 생성 전 확인사항:
- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint`)
- [ ] (API 변경 시) Swagger 문서가 업데이트되었습니다
- [ ] (필요 시) 테스트 코드를 작성했습니다

## Screenshots (Optional)
N/A

## Additional Notes
실서버 로그에서 확인한 실제 장애 메시지:
`DataTypeNotSupportedError: Data type "Object" in "UserAgreement.agreeAt" is not supported by "postgres" database.`