### PR TITLE
Fix: AdminJS 런타임 모듈 로더 오류 수정 (#191)

### DIFF
--- a/src/modules/admin/admin.module.ts
+++ b/src/modules/admin/admin.module.ts
@@ -1,6 +1,7 @@
 import { DynamicModule, Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import type { ActionRequest } from 'adminjs';
+import { createRequire } from 'module';
 import { join } from 'path';
 import { EventRewardFacade } from '../event/application/facades/event-reward.facade';
 import { Event } from '../event/domain/entities/event.entity';
@@ -11,6 +12,7 @@ import { GrantFeedbackRewardAdminActionService } from './application/services/gr
 const nativeDynamicImport = Function('specifier', 'return import(specifier)') as (
     specifier: string
 ) => Promise<unknown>;
+const requireModule = createRequire(__filename);
 
 type AdminNestModuleExports = {
     AdminModule: {
@@ -44,7 +46,7 @@ type AdminJsTypeOrmModuleExports = {
             (adminNestModule as AdminNestModuleExports).AdminModule.createAdminAsync({
                 imports: [EventModule, ConfigModule],
                 inject: [ConfigService, EventRewardFacade],
-                useFactory: async (
+                useFactory: (
                     configService: ConfigService,
                     eventRewardFacade: EventRewardFacade
                 ) => {
@@ -52,14 +54,12 @@ type AdminJsTypeOrmModuleExports = {
                         eventRewardFacade
                     );
 
-                    const [adminJsModule, adminJsTypeOrmModule] = await Promise.all([
-                        nativeDynamicImport('adminjs'),
-                        nativeDynamicImport('@adminjs/typeorm'),
-                    ]);
-                    const { default: AdminJS, ComponentLoader } =
-                        adminJsModule as AdminJsModuleExports;
-                    const { Database, Resource } =
-                        adminJsTypeOrmModule as AdminJsTypeOrmModuleExports;
+                    const adminJsModule = requireModule('adminjs') as AdminJsModuleExports;
+                    const adminJsTypeOrmModule = requireModule(
+                        '@adminjs/typeorm'
+                    ) as AdminJsTypeOrmModuleExports;
+                    const { default: AdminJS, ComponentLoader } = adminJsModule;
+                    const { Database, Resource } = adminJsTypeOrmModule;
 
                     AdminJS.registerAdapter({ Database, Resource });
 
@@ -79,7 +79,7 @@ type AdminJsTypeOrmModuleExports = {
                         );
                     }
 
-                    return {
+                    return Promise.resolve({
                         adminJsOptions: {
                             rootPath: '/admin',
                             componentLoader,
@@ -136,7 +136,7 @@ type AdminJsTypeOrmModuleExports = {
                                 secure: configService.get<string>('NODE_ENV') === 'production',
                             },
                         },
-                    };
+                    });
                 },
             })
         ),


### PR DESCRIPTION
## Summary
AdminJS 초기화 과정에서 발생한 런타임 ESM 로더 오류(`ERR_VM_MODULE_LINK_FAILURE`)를 수정했습니다. 컨테이너 런타임(Node 20)에서 불안정했던 dynamic import 경로를 `createRequire` 기반 로딩으로 바꿔 부팅 안정성을 확보했습니다.

## Changes
- `src/modules/admin/admin.module.ts`
  - `adminjs`, `@adminjs/typeorm` 로딩을 `createRequire(__filename)` 기반으로 변경
  - `useFactory` 반환을 `Promise.resolve(...)` 형태로 정리해 린트 규칙 충족

## Type of Change
- [x] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [ ] Documentation (문서 변경)
- [ ] Chore (빌드, 설정 등)

## Target Environment
- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues
- Closes #191

## Testing
- [x] 단위 테스트 통과
- [ ] E2E 테스트 통과

실행:
- `pnpm run lint`
- `pnpm run test`
- `pnpm exec nest build`

결과:
- lint 통과
- test 통과 (3 suites, 11 tests)
- SWC build 통과

## Checklist
- [x] 코드 컨벤션 준수
- [x] Git 컨벤션 준수
- [x] 네이밍 컨벤션 준수
- [x] 로컬 검증 완료
- [ ] (API 변경 시) Swagger 문서 업데이트
- [ ] (필요 시) 테스트 코드 작성

## Screenshots (Optional)
N/A

## Additional Notes
실패한 dev CD(run 22543871368)에서 `Error: request for './lib/index.js' is not in cache`를 서버 로그로 직접 확인했고, 해당 재현 경로를 기준으로 수정했습니다.