### PR TITLE
Fix: deploy-dev가 AR 이미지 레포를 env에서 사용하도록 수정 (#205)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -139,7 +139,7 @@ jobs:
                       IMAGE_REPO="${IMAGE_REPO%:*}"
                       export DOCKER_IMAGE="$IMAGE_REPO"
                       gcloud auth print-access-token | docker login -u oauth2accesstoken --password-stdin https://asia-northeast3-docker.pkg.dev
-                      DC='sudo -E docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.bluegreen.yml'
+                      DC='sudo DOCKER_IMAGE="$DOCKER_IMAGE" docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.bluegreen.yml'
 
                       sudo docker network create folioo-network || true
 


### PR DESCRIPTION
## Summary
`deploy-dev` 원격 SSH 배포 단계에서 `DOCKER_IMAGE`가 compose 실행 환경으로 전달되지 않아 잘못된 Artifact Registry 경로(`folioo-ai`)를 참조하던 문제를 수정했습니다.

## Changes
- remote deploy command의 compose 실행을 `sudo DOCKER_IMAGE=\"$DOCKER_IMAGE\" docker compose ...` 형태로 변경
- blue/green deploy 스크립트가 workflow env의 이미지 레포지토리를 일관되게 사용하도록 보장

## Type of Change
- [x] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [ ] Documentation (문서 변경)
- [x] Chore (빌드, 설정 등)

## Target Environment
- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues
- Closes #205

## Testing
- [ ] Postman/Swagger로 API 호출 확인
- [ ] 단위 테스트 통과
- [ ] E2E 테스트 통과
- [x] `actionlint .github/workflows/deploy-dev.yml` 실행 (기존 shellcheck 경고만 확인)
- [x] PR 생성 후 `CD (Deploy to GCP - Dev)` 워크플로 결과 확인 예정

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [ ] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [ ] 로컬에서 린트가 통과합니다 (`pnpm run lint`)
- [ ] (API 변경 시) Swagger 문서가 업데이트되었습니다
- [ ] (필요 시) 테스트 코드를 작성했습니다

## Screenshots (Optional)
N/A

## Additional Notes
이번 변경은 deploy workflow 경로 강제 목적의 단일 라인 수정입니다. 병합 후 dev 배포 워크플로 상태를 우선 확인하고, green 확인 시 `dev -> main` 승격 PR(#207)을 계속 진행합니다.