### PR TITLE
Fix: /home/folioo 생성 후 prod env 파일 이동 처리 (#205)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,6 +96,7 @@ jobs:
                     --tunnel-through-iap \
                     --quiet \
                     --command="
+                      sudo mkdir -p /home/folioo
                       sudo mv ~/.env.prod /home/folioo/.env.prod
                       sudo chmod 600 /home/folioo/.env.prod
                     "


### PR DESCRIPTION
## Summary
Prod 배포 워크플로에서 `.env.prod`를 `/home/folioo/.env.prod`로 이동할 때, 대상 디렉토리가 아직 생성되지 않아 실패하던 문제를 수정했습니다.

## Changes
- `.github/workflows/deploy.yml`의 `Refresh Environment Variables from Secret Manager` 단계 SSH command에 `sudo mkdir -p /home/folioo` 추가

## Type of Change
- [x] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [ ] Documentation (문서 변경)
- [x] Chore (빌드, 설정 등)

## Target Environment
- [ ] Dev (`dev`)
- [x] Prod (`main`)

## Related Issues
- Closes #205

## Testing
- [x] 실패 로그 확인: `mv ... /home/folioo/.env.prod: No such file or directory`
- [x] 워크플로 수정 후 PR checks 확인 예정

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [ ] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [ ] 로컬에서 린트가 통과합니다 (`pnpm run lint`)
- [ ] (API 변경 시) Swagger 문서가 업데이트되었습니다
- [ ] (필요 시) 테스트 코드를 작성했습니다

## Screenshots (Optional)
N/A

## Additional Notes
프로덕션 배포 실패(run `22557172352`)의 직접 원인 제거 목적의 최소 수정입니다.