### PR TITLE
Fix: supabase CLI 버전 2.75.0 고정 (#215)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -59,6 +59,8 @@ jobs:
 
             - name: Set up Supabase CLI
               uses: supabase/setup-cli@v1
+              with:
+                  version: 2.75.0
 
             - name: Apply Supabase migrations (dev)
               run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,8 @@ jobs:
 
             - name: Set up Supabase CLI
               uses: supabase/setup-cli@v1
+              with:
+                  version: 2.75.0
 
             - name: Apply Supabase migrations (prod)
               run: |


### PR DESCRIPTION
## Summary
- `supabase/setup-cli@v1`이 구버전 CLI를 설치해 `config.toml`의 신규 키 파싱 실패
- `deploy-dev.yml`, `deploy.yml` 모두 `version: 2.75.0`으로 고정

## Type of Change
- [x] Fix

## Target Environment
- Dev
- Prod

## Related Issues
Closes #215

## Testing
CI 자동 테스트

## Checklist
- [x] supabase db push 성공 확인

## Screenshots
N/A

## Additional Notes
로컬 supabase CLI 버전: 2.75.0