### PR TITLE
Fix: blue-green 배포 --remove-orphans 추가 (#215)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -181,7 +181,7 @@ jobs:
 
                       \$DC --profile blue --profile green pull
                       echo \"Starting green slot (dev-\$GREEN_SLOT)\"
-                      \$DC --profile \$GREEN_SLOT up -d
+                      \$DC --profile \$GREEN_SLOT up -d --remove-orphans
 
                       # ── Health Check ──
                       GREEN_CONTAINER=\$(\$DC ps --format json 2>/dev/null | jq -sr \".[] | select(.Service == \\\"dev-\$GREEN_SLOT\\\") | .Name\")

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -181,7 +181,7 @@ jobs:
 
                       \$DC --profile blue --profile green pull
                       echo \"Starting green slot (prod-\$GREEN_SLOT)\"
-                      \$DC --profile \$GREEN_SLOT up -d
+                      \$DC --profile \$GREEN_SLOT up -d --remove-orphans
 
                       # ── Health Check ──
                       GREEN_CONTAINER=\$(\$DC ps --format json 2>/dev/null | jq -sr \".[] | select(.Service == \\\"prod-\$GREEN_SLOT\\\") | .Name\")


### PR DESCRIPTION
compose project 변경 시 orphan 컨테이너로 인한 name conflict 방지. 다음 배포부터는 자동으로 클린업됨.