### PR TITLE
Chore: terraform outputs 중복 제거 및 infra README 현실화 (#215)

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -4,9 +4,7 @@ This directory is the Terraform skeleton for Folioo's GCP migration.
 
 ## Scope
 
-- Included: Terraform foundation, provider setup, backend contract, module contracts.
-- Implemented: WIF (Workload Identity Federation), Artifact Registry, CI identity.
-- Deferred: concrete networking/compute/cloudflare implementation.
+- Implemented: WIF, Artifact Registry, CI identity, GCE compute (dev/prod), networking (Cloud NAT), Cloudflare tunnel.
 - Excluded:
     - Cloud SQL: Folioo uses Supabase as fixed external DB.
     - GCS storage module: not required by current Folioo server architecture.
@@ -73,8 +71,12 @@ Required GitHub Secrets: `GCP_PROJECT_ID`, `WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`
 
 ## Key Outputs
 
-| Output                    | Purpose                                    |
-| ------------------------- | ------------------------------------------ |
-| `wif_provider`            | WIF provider resource name (GitHub secret) |
-| `github_actions_sa_email` | SA email for CI (GitHub secret)            |
-| `artifact_registry_url`   | Docker image URL prefix                    |
+| Output                    | Purpose                                                      |
+| ------------------------- | ------------------------------------------------------------ |
+| `wif_provider`            | WIF provider resource name (GitHub secret)                   |
+| `github_actions_sa_email` | SA email for CI (GitHub secret)                              |
+| `artifact_registry_url`   | Docker image URL prefix                                      |
+| `deploy_config`           | JSON with GCE names/zones — exported to GCS for CD workflows |
+| `nat_static_egress_ip`    | Static egress IP for Cloud NAT                               |
+| `dev_tunnel_token`        | Cloudflare tunnel token for dev cloudflared                  |
+| `prod_tunnel_token`       | Cloudflare tunnel token for prod cloudflared                 |

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -29,26 +29,6 @@ output "deploy_config" {
   })
 }
 
-output "dev_vm_name" {
-  description = "Dev VM name"
-  value       = module.compute.dev_instance_name
-}
-
-output "dev_vm_zone" {
-  description = "Dev VM zone"
-  value       = module.compute.dev_instance_zone
-}
-
-output "prod_vm_name" {
-  description = "Prod VM name"
-  value       = module.compute.prod_instance_name
-}
-
-output "prod_vm_zone" {
-  description = "Prod VM zone"
-  value       = module.compute.prod_instance_zone
-}
-
 output "nat_static_egress_ip" {
   description = "Static egress IP reserved for Cloud NAT"
   value       = module.networking.nat_static_egress_ip


### PR DESCRIPTION
## Summary

Terraform outputs 정리 및 infra 문서를 현재 구현 상태에 맞게 업데이트합니다.

## Changes

- **infra/outputs.tf**: `deploy_config`에 이미 포함된 개별 VM outputs 4개 제거 (`dev_vm_name`, `dev_vm_zone`, `prod_vm_name`, `prod_vm_zone`)
- **infra/README.md**: "Deferred: networking/compute/cloudflare" → 실제 구현 완료 상태로 수정, Key Outputs 테이블에 현재 output 전체 반영

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Chore (빌드, 설정 등)

## Target Environment

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

- Closes #215

## Testing

- [x] `terraform validate` 통과 확인 (outputs 제거는 state에 영향 없음)

## Checklist

- [x] 코드 컨벤션을 준수했습니다
- [x] Git 컨벤션을 준수했습니다
- [x] 네이밍 컨벤션을 준수했습니다
- [x] 로컬에서 빌드가 성공합니다
- [x] 로컬에서 린트가 통과합니다

## Screenshots

N/A

## Additional Notes

`outputs.tf`에서 개별 VM output 제거는 state에 영향 없음 — CD 워크플로우는 `deploy_config` JSON을 단독으로 사용하므로 개별 output은 불필요.