### PR TITLE
Chore: 전체 문서 정합성 수정 및 CLAUDE.md 업데이트 (#215)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,25 +11,34 @@ Folioo는 포트폴리오 관리 및 첨삭 플랫폼입니다. NestJS + TypeORM
 - **Runtime**: Node.js 20+
 - **Framework**: NestJS 10.x
 - **ORM**: TypeORM
-- **Database**: PostgreSQL
+- **Database**: PostgreSQL (로컬: Docker, dev/prod: Supabase 외부 연결)
+- **Cache**: Upstash Redis REST API (dev/prod) / ioredis Docker (로컬)
 - **Package Manager**: pnpm
 - **Language**: TypeScript (Strict Mode)
+- **배포**: GCE Blue-Green (docker-compose.infra.yml + dev/prod overlay)
+- **이미지 레지스트리**: GCP Artifact Registry (`asia-northeast3-docker.pkg.dev/folioo-488916/folioo-docker/folioo-server`)
 
 ## 문서 경로
 
 상세한 내용은 아래 문서 참조:
 
-| 문서          | 경로                                     |
-| ------------- | ---------------------------------------- |
-| 아키텍처      | `docs/architecture/ARCHITECTURE.md`      |
-| 도메인 전략   | `docs/architecture/DOMAIN_STRATEGY.md`   |
-| ERD/DB 설계   | `docs/architecture/ERD.md`               |
-| 코드 스타일   | `docs/development/CODE_STYLE.md`         |
-| 예외 처리     | `docs/development/ERROR_HANDLING.md`     |
-| Git 컨벤션    | `docs/development/GIT_CONVENTIONS.md`    |
-| 네이밍 컨벤션 | `docs/development/NAMING_CONVENTIONS.md` |
-| PR 템플릿     | `.github/PULL_REQUEST_TEMPLATE.md`       |
-| Issue 템플릿  | `.github/ISSUE_TEMPLATE/`                |
+| 문서              | 경로                                     |
+| ----------------- | ---------------------------------------- |
+| 아키텍처          | `docs/architecture/ARCHITECTURE.md`      |
+| 도메인 전략       | `docs/architecture/DOMAIN_STRATEGY.md`   |
+| ERD/DB 설계       | `docs/architecture/ERD.md`               |
+| 코드 스타일       | `docs/development/CODE_STYLE.md`         |
+| 예외 처리         | `docs/development/ERROR_HANDLING.md`     |
+| Git 컨벤션        | `docs/development/GIT_CONVENTIONS.md`    |
+| 네이밍 컨벤션     | `docs/development/NAMING_CONVENTIONS.md` |
+| API 현황          | `docs/API.md`                            |
+| 환경변수 관리     | `docs/infrastructure/ENV_MANAGEMENT.md`  |
+| Redis/Cache       | `docs/infrastructure/REDIS.md`           |
+| 비용 추정         | `docs/infrastructure/COST_ESTIMATE.md`   |
+| 인프라(Terraform) | `infra/README.md`                        |
+| Env 계약          | `infra/docs/env-contract.md`             |
+| PR 템플릿         | `.github/PULL_REQUEST_TEMPLATE.md`       |
+| Issue 템플릿      | `.github/ISSUE_TEMPLATE/`                |
 
 ## 핵심 규칙
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,7 +18,7 @@
 services:
     # ── Dev Blue Slot ──
     dev-blue:
-        image: ${DOCKER_IMAGE:-asia-northeast3-docker.pkg.dev/folioo-ai/folioo-docker/folioo-server}:dev
+        image: ${DOCKER_IMAGE:-asia-northeast3-docker.pkg.dev/folioo-488916/folioo-docker/folioo-server}:dev
         restart: unless-stopped
         env_file:
             - path: .env.dev
@@ -50,7 +50,7 @@ services:
 
     # ── Dev Green Slot ──
     dev-green:
-        image: ${DOCKER_IMAGE:-asia-northeast3-docker.pkg.dev/folioo-ai/folioo-docker/folioo-server}:dev
+        image: ${DOCKER_IMAGE:-asia-northeast3-docker.pkg.dev/folioo-488916/folioo-docker/folioo-server}:dev
         restart: unless-stopped
         env_file:
             - path: .env.dev

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,7 +18,7 @@
 services:
     # ── Production Blue Slot ──
     prod-blue:
-        image: ${DOCKER_IMAGE:-asia-northeast3-docker.pkg.dev/folioo-ai/folioo-docker/folioo-server}:latest
+        image: ${DOCKER_IMAGE:-asia-northeast3-docker.pkg.dev/folioo-488916/folioo-docker/folioo-server}:latest
         restart: unless-stopped
         env_file:
             - path: .env.prod
@@ -50,7 +50,7 @@ services:
 
     # ── Production Green Slot ──
     prod-green:
-        image: ${DOCKER_IMAGE:-asia-northeast3-docker.pkg.dev/folioo-ai/folioo-docker/folioo-server}:latest
+        image: ${DOCKER_IMAGE:-asia-northeast3-docker.pkg.dev/folioo-488916/folioo-docker/folioo-server}:latest
         restart: unless-stopped
         env_file:
             - path: .env.prod

--- a/docs/API.md
+++ b/docs/API.md
@@ -15,10 +15,10 @@ Notes:
 
 ## Environments
 
-- Dev base URL: `https://folioo-dev-api.log8.kr`
-- Swagger UI: `https://folioo-dev-api.log8.kr/api`
-- OpenAPI JSON: `https://folioo-dev-api.log8.kr/api-json`
-- Health check (public): `https://folioo-dev-api.log8.kr/health`
+- Dev base URL: `https://dev-api.folioo.ai.kr`
+- Swagger UI: `https://dev-api.folioo.ai.kr/api`
+- OpenAPI JSON: `https://dev-api.folioo.ai.kr/api-json`
+- Health check (public): `https://dev-api.folioo.ai.kr/health`
 
 ## Auth Model (How Requests Are Authorized)
 
@@ -32,7 +32,7 @@ Notes:
 
 Open:
 
-`https://folioo-dev-api.log8.kr/api`
+`https://dev-api.folioo.ai.kr/api`
 
 This may prompt for Basic Auth credentials (configured by `SWAGGER_USER` / `SWAGGER_PASSWORD` in non-local).
 
@@ -42,9 +42,9 @@ Do NOT try to execute OAuth redirects from Swagger.
 
 Open one of these in a new browser tab:
 
-`https://folioo-dev-api.log8.kr/auth/kakao`
+`https://dev-api.folioo.ai.kr/auth/kakao`
 
-`https://folioo-dev-api.log8.kr/auth/google`
+`https://dev-api.folioo.ai.kr/auth/google`
 
 After completing the social login flow, the server sets an `httpOnly` cookie `refreshToken` and redirects to the client.
 
@@ -100,7 +100,7 @@ node scripts/smoke-dev-api.mjs --mutate --file ./sample.pdf
 
 | Option               | Default                           | Description                        |
 | -------------------- | --------------------------------- | ---------------------------------- |
-| `--base <url>`       | `https://folioo-dev-api.log8.kr`  | Dev server base URL                |
+| `--base <url>`       | `https://dev-api.folioo.ai.kr`    | Dev server base URL                |
 | `--token-env <name>` | `FOLIOO_ACCESS_TOKEN`             | Env var containing access token    |
 | `--mutate`           | off                               | Enable POST/PATCH/DELETE endpoints |
 | `--file <path>`      | _(none)_                          | Attach file to multipart endpoints |

--- a/docs/development/DEV_SEED.md
+++ b/docs/development/DEV_SEED.md
@@ -70,7 +70,7 @@ curl -s http://localhost:3000/ticket-products | jq '.result | length'
 # Expected: 6
 
 # Dev server
-curl -s https://folioo-dev-api.log8.kr/ticket-products | jq '.result | length'
+curl -s https://dev-api.folioo.ai.kr/ticket-products | jq '.result | length'
 # Expected: 6
 ```
 
@@ -84,12 +84,17 @@ If the seed ran correctly, preflight succeeds and subsequent `POST /payments` us
 If the dev database is wiped (see `docs/development/DEV_DB_RESET.md`), simply restart the server.
 TypeORM `synchronize: true` recreates tables, and the seed service re-inserts all 6 products on the next startup.
 
+**로컬** 환경에서 DB를 초기화하려면:
+
 ```bash
-# 1. Reset DB (deletes all data)
-docker compose --env-file .env.dev -f docker-compose.dev.yml down -v
-docker compose --env-file .env.dev -f docker-compose.dev.yml up -d --force-recreate --wait
+# 1. Reset local DB (deletes all data)
+docker compose down -v
+docker compose up -d --force-recreate --wait
 
 # 2. Server restart triggers seed automatically
 # 3. Verify
-curl -s https://folioo-dev-api.log8.kr/ticket-products | jq '.result | length'
+curl -s http://localhost:3000/ticket-products | jq '.result | length'
 ```
+
+**dev 서버**는 Supabase 외부 DB를 사용하므로, DB 초기화가 필요하면 Supabase 대시보드를 사용하세요.
+앱 재시작만 필요한 경우 `supabase db push` 없이 컨테이너만 재시작하면 seed가 자동 실행됩니다.

--- a/docs/infrastructure/ENV_MANAGEMENT.md
+++ b/docs/infrastructure/ENV_MANAGEMENT.md
@@ -7,14 +7,21 @@ This project manages runtime env values with GCP Secret Manager.
 - `folioo-dev-config`
 - `folioo-prod-config`
 
-### GitHub Secrets (minimum set)
+### GitHub Secrets (current set)
 
-- `GCP_PROJECT_ID`
-- `WIF_PROVIDER`
-- `WIF_SERVICE_ACCOUNT`
-- `TF_STATE_BUCKET`
+| Secret                 | Purpose                                                         |
+| ---------------------- | --------------------------------------------------------------- |
+| `GCP_PROJECT_ID`       | GCP 프로젝트 ID (`folioo-488916`)                               |
+| `WIF_PROVIDER`         | Workload Identity Federation provider 리소스명                  |
+| `WIF_SERVICE_ACCOUNT`  | GitHub Actions 서비스 계정 이메일                               |
+| `TF_STATE_BUCKET`      | Terraform state / deploy-config GCS 버킷명                      |
+| `SUPABASE_DEV_DB_URL`  | 마이그레이션 전용 dev DB URL (`supabase db push` 실행 시 사용)  |
+| `SUPABASE_PROD_DB_URL` | 마이그레이션 전용 prod DB URL (`supabase db push` 실행 시 사용) |
 
-Legacy secrets (`ENV_DEV`, `ENV_PROD`, `LIGHTSAIL_*`, `DOCKERHUB_*`, `DOCKER_IMAGE`) are removed.
+> `SUPABASE_*_DB_URL` GitHub Secrets는 CI/CD에서 `supabase db push` 마이그레이션 전용입니다.
+> 앱 런타임에서 사용하는 DB 연결 정보는 Secret Manager의 `folioo-dev-config` / `folioo-prod-config`에 있습니다.
+
+Removed legacy secrets: `ENV_DEV`, `ENV_PROD`, `LIGHTSAIL_*`, `DOCKERHUB_*`, `DOCKER_IMAGE`
 
 ### How CI/CD loads env
 

--- a/infra/docs/backend-bootstrap.md
+++ b/infra/docs/backend-bootstrap.md
@@ -29,7 +29,7 @@ a manual bootstrap sequence is required.
 
 ```bash
 gcloud auth login
-gcloud config set project folioo-ai
+gcloud config set project folioo-488916
 gcloud auth application-default login
 ```
 
@@ -37,10 +37,10 @@ gcloud auth application-default login
 
 ```bash
 # Bucket name must be globally unique
-export TF_STATE_BUCKET="folioo-ai-tfstate"
+export TF_STATE_BUCKET="folioo-488916-tfstate"
 
 gcloud storage buckets create "gs://${TF_STATE_BUCKET}" \
-  --project=folioo-ai \
+  --project=folioo-488916 \
   --location=asia-northeast3 \
   --uniform-bucket-level-access \
   --public-access-prevention
@@ -54,7 +54,7 @@ gcloud storage buckets update "gs://${TF_STATE_BUCKET}" \
 
 ```bash
 cat > /tmp/terraform.tfvars <<'EOF'
-project_id = "folioo-ai"
+project_id = "folioo-488916"
 region     = "asia-northeast3"
 zone       = "asia-northeast3-a"
 
@@ -81,7 +81,7 @@ gcloud services enable \
   artifactregistry.googleapis.com \
   secretmanager.googleapis.com \
   compute.googleapis.com \
-  --project=folioo-ai
+  --project=folioo-488916
 ```
 
 ### 5. Local Terraform apply
@@ -116,25 +116,25 @@ terraform output -raw wif_provider
 
 # Service account email
 terraform output -raw github_actions_sa_email
-# → github-actions@folioo-ai.iam.gserviceaccount.com
+# → github-actions@folioo-488916.iam.gserviceaccount.com
 
 # Artifact Registry URL prefix
 terraform output -raw artifact_registry_url
-# → asia-northeast3-docker.pkg.dev/folioo-ai/folioo-docker
+# → asia-northeast3-docker.pkg.dev/folioo-488916/folioo-docker
 ```
 
 Set these as GitHub repository secrets:
 
 | GitHub Secret         | Value Source                               |
 | --------------------- | ------------------------------------------ |
-| `GCP_PROJECT_ID`      | `folioo-ai`                                |
+| `GCP_PROJECT_ID`      | `folioo-488916`                            |
 | `WIF_PROVIDER`        | `terraform output wif_provider`            |
 | `WIF_SERVICE_ACCOUNT` | `terraform output github_actions_sa_email` |
-| `TF_STATE_BUCKET`     | `folioo-ai-tfstate`                        |
+| `TF_STATE_BUCKET`     | `folioo-488916-tfstate`                    |
 
 ```bash
 # Using GitHub CLI
-gh secret set GCP_PROJECT_ID --body "folioo-ai"
+gh secret set GCP_PROJECT_ID --body "folioo-488916"
 gh secret set WIF_PROVIDER --body "$(terraform output -raw wif_provider)"
 gh secret set WIF_SERVICE_ACCOUNT --body "$(terraform output -raw github_actions_sa_email)"
 gh secret set TF_STATE_BUCKET --body "${TF_STATE_BUCKET}"
@@ -145,16 +145,16 @@ gh secret set TF_STATE_BUCKET --body "${TF_STATE_BUCKET}"
 ```bash
 # Verify WIF pool exists
 gcloud iam workload-identity-pools list \
-  --project=folioo-ai --location=global \
+  --project=folioo-488916 --location=global \
   --format="value(name)"
 
 # Verify AR repo exists
 gcloud artifacts repositories list \
-  --project=folioo-ai --location=asia-northeast3
+  --project=folioo-488916 --location=asia-northeast3
 
 # Verify SA exists
 gcloud iam service-accounts list \
-  --project=folioo-ai \
+  --project=folioo-488916 \
   --filter="email:github-actions@"
 ```
 
@@ -179,7 +179,7 @@ terraform init -backend-config="bucket=${TF_STATE_BUCKET}"
 Ensure you have `roles/owner` or sufficient IAM roles on the project:
 
 ```bash
-gcloud projects get-iam-policy folioo-ai \
+gcloud projects get-iam-policy folioo-488916 \
   --flatten="bindings[].members" \
   --filter="bindings.members:$(gcloud config get-value account)"
 ```

--- a/infra/docs/env-contract.md
+++ b/infra/docs/env-contract.md
@@ -9,14 +9,27 @@ This contract defines environment keys for local, dev, and prod.
 
 Both secret payloads must keep the same key names used by Finders-style runtime loading.
 
-## Required Keys
+## GitHub Secrets (CI/CD 전용)
+
+앱 런타임 env와는 별개로 GitHub Actions 워크플로우에서 직접 사용하는 secrets:
+
+| Secret                 | Used by          | Purpose                              |
+| ---------------------- | ---------------- | ------------------------------------ |
+| `SUPABASE_DEV_DB_URL`  | `deploy-dev.yml` | `supabase db push` 마이그레이션 실행 |
+| `SUPABASE_PROD_DB_URL` | `deploy.yml`     | `supabase db push` 마이그레이션 실행 |
+
+## Required Keys (Secret Manager payload)
 
 - `APP_PROFILE`
-- `DB_HOST` (fallback)
-- `DB_PORT` (fallback)
-- `DB_USERNAME` (fallback)
-- `DB_PASSWORD` (fallback)
-- `DB_SCHEMA` (fallback)
+- `SUPABASE_DB_URL` (dev/prod 필수 — 앱 런타임 DB 연결)
+- `CACHE_DRIVER` (`upstash` for dev/prod)
+- `UPSTASH_REDIS_REST_URL` (dev/prod 필수)
+- `UPSTASH_REDIS_REST_TOKEN` (dev/prod 필수)
+- `DB_HOST` (local fallback only)
+- `DB_PORT` (local fallback only)
+- `DB_USERNAME` (local fallback only)
+- `DB_PASSWORD` (local fallback only)
+- `DB_SCHEMA` (local fallback only)
 - `REDIS_HOST` (ioredis fallback)
 - `REDIS_PORT` (ioredis fallback)
 - `JWT_SECRET_TOKEN`


### PR DESCRIPTION
## Summary

교차 검증을 통해 발견된 문서 전반의 outdated/불일치 내용을 일괄 수정합니다.

## Changes

- **CLAUDE.md**: 기술 스택에 Supabase/Upstash/배포 방식 추가, 문서 경로 테이블 확장 (ENV_MANAGEMENT, REDIS, COST_ESTIMATE, infra 문서 등 추가)
- **docs/API.md**: dev 도메인 `folioo-dev-api.log8.kr` → `dev-api.folioo.ai.kr` (전체)
- **docs/development/DEV_SEED.md**: 동일 도메인 수정 + DB reset 명령을 로컬/dev 컨텍스트로 분리 (dev는 Supabase 사용)
- **docs/infrastructure/ENV_MANAGEMENT.md**: `SUPABASE_DEV_DB_URL`, `SUPABASE_PROD_DB_URL` GitHub Secrets 추가 (CI 마이그레이션 전용)
- **infra/docs/env-contract.md**: GitHub Secrets 섹션 신설, `SUPABASE_DB_URL`을 dev/prod 필수로 명확화, DB fallback keys를 local only로 재분류
- **infra/docs/backend-bootstrap.md**: GCP 프로젝트 ID `folioo-ai` → `folioo-488916` (전체)
- **docker-compose.dev.yml, docker-compose.prod.yml**: fallback 이미지 프로젝트 ID `folioo-ai` → `folioo-488916`

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Chore

## Target Environment

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

- Closes #215

## Testing

- [x] 코드 변경 없음 (문서/compose fallback 이미지 경로만 수정)
- [x] compose fallback은 CI에서 DOCKER_IMAGE env로 덮어쓰므로 배포에 영향 없음

## Checklist

- [x] 코드 컨벤션을 준수했습니다
- [x] Git 컨벤션을 준수했습니다

## Screenshots

N/A

## Additional Notes

N/A