### PR TITLE
Fix: Supabase migration DB URL 가드 추가 (#231)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -69,7 +69,14 @@ jobs:
                     exit 1
                   fi
 
-                  supabase db push --db-url "${{ secrets.SUPABASE_DEV_DB_URL }}"
+                  DB_URL="${{ secrets.SUPABASE_DEV_DB_URL }}"
+                  if printf '%s' "$DB_URL" | grep -q ':6543'; then
+                    echo "::error::SUPABASE_DEV_DB_URL points to transaction pooler port 6543."
+                    echo "::error::Use a migration-safe connection string (direct DB or session-mode 5432)."
+                    exit 1
+                  fi
+
+                  supabase db push --db-url "$DB_URL"
 
             - name: Authenticate to Google Cloud
               uses: google-github-actions/auth@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,14 @@ jobs:
                     exit 1
                   fi
 
-                  supabase db push --db-url "${{ secrets.SUPABASE_PROD_DB_URL }}"
+                  DB_URL="${{ secrets.SUPABASE_PROD_DB_URL }}"
+                  if printf '%s' "$DB_URL" | grep -q ':6543'; then
+                    echo "::error::SUPABASE_PROD_DB_URL points to transaction pooler port 6543."
+                    echo "::error::Use a migration-safe connection string (direct DB or session-mode 5432)."
+                    exit 1
+                  fi
+
+                  supabase db push --db-url "$DB_URL"
 
             - name: Authenticate to Google Cloud
               uses: google-github-actions/auth@v2

--- a/docs/infrastructure/ENV_MANAGEMENT.md
+++ b/docs/infrastructure/ENV_MANAGEMENT.md
@@ -9,17 +9,18 @@ This project manages runtime env values with GCP Secret Manager.
 
 ### GitHub Secrets (current set)
 
-| Secret                 | Purpose                                                         |
-| ---------------------- | --------------------------------------------------------------- |
-| `GCP_PROJECT_ID`       | GCP 프로젝트 ID (`folioo-488916`)                               |
-| `WIF_PROVIDER`         | Workload Identity Federation provider 리소스명                  |
-| `WIF_SERVICE_ACCOUNT`  | GitHub Actions 서비스 계정 이메일                               |
-| `TF_STATE_BUCKET`      | Terraform state / deploy-config GCS 버킷명                      |
-| `SUPABASE_DEV_DB_URL`  | 마이그레이션 전용 dev DB URL (`supabase db push` 실행 시 사용)  |
-| `SUPABASE_PROD_DB_URL` | 마이그레이션 전용 prod DB URL (`supabase db push` 실행 시 사용) |
+| Secret                 | Purpose                                                                       |
+| ---------------------- | ----------------------------------------------------------------------------- |
+| `GCP_PROJECT_ID`       | GCP 프로젝트 ID (`folioo-488916`)                                             |
+| `WIF_PROVIDER`         | Workload Identity Federation provider 리소스명                                |
+| `WIF_SERVICE_ACCOUNT`  | GitHub Actions 서비스 계정 이메일                                             |
+| `TF_STATE_BUCKET`      | Terraform state / deploy-config GCS 버킷명                                    |
+| `SUPABASE_DEV_DB_URL`  | 마이그레이션 전용 dev DB URL (`supabase db push` 실행 시 사용, `:6543` 금지)  |
+| `SUPABASE_PROD_DB_URL` | 마이그레이션 전용 prod DB URL (`supabase db push` 실행 시 사용, `:6543` 금지) |
 
 > `SUPABASE_*_DB_URL` GitHub Secrets는 CI/CD에서 `supabase db push` 마이그레이션 전용입니다.
 > 앱 런타임에서 사용하는 DB 연결 정보는 Secret Manager의 `folioo-dev-config` / `folioo-prod-config`에 있습니다.
+> `SUPABASE_*_DB_URL`에는 transaction pooler 포트(`:6543`)를 사용하지 않습니다. migration은 direct/session `:5432` 경로를 사용하세요.
 
 Removed legacy secrets: `ENV_DEV`, `ENV_PROD`, `LIGHTSAIL_*`, `DOCKERHUB_*`, `DOCKER_IMAGE`
 

--- a/infra/docs/env-contract.md
+++ b/infra/docs/env-contract.md
@@ -13,10 +13,13 @@ Both secret payloads must keep the same key names used by Finders-style runtime 
 
 앱 런타임 env와는 별개로 GitHub Actions 워크플로우에서 직접 사용하는 secrets:
 
-| Secret                 | Used by          | Purpose                              |
-| ---------------------- | ---------------- | ------------------------------------ |
-| `SUPABASE_DEV_DB_URL`  | `deploy-dev.yml` | `supabase db push` 마이그레이션 실행 |
-| `SUPABASE_PROD_DB_URL` | `deploy.yml`     | `supabase db push` 마이그레이션 실행 |
+| Secret                 | Used by          | Purpose                                             |
+| ---------------------- | ---------------- | --------------------------------------------------- |
+| `SUPABASE_DEV_DB_URL`  | `deploy-dev.yml` | `supabase db push` 마이그레이션 실행 (`:6543` 금지) |
+| `SUPABASE_PROD_DB_URL` | `deploy.yml`     | `supabase db push` 마이그레이션 실행 (`:6543` 금지) |
+
+> Migration URL rule: `SUPABASE_*_DB_URL` must not use transaction pooler port `6543`.
+> Use direct/session `5432` connection for migration jobs.
 
 ## Required Keys (Secret Manager payload)
 


### PR DESCRIPTION
## Summary

Supabase migration 단계에서 transaction pooler 포트(`:6543`) URL이 설정되면 `supabase db push`가 `42P05`로 실패하는 문제를 사전에 차단하도록 배포 워크플로우 가드를 추가했습니다.
또한 관련 env 문서에 migration URL 규칙을 명시해 운영 실수를 줄였습니다.

## Changes

- `.github/workflows/deploy-dev.yml`에 `SUPABASE_DEV_DB_URL` preflight 검증 추가 (`:6543` 감지 시 명시적 실패)
- `.github/workflows/deploy.yml`에 `SUPABASE_PROD_DB_URL` preflight 검증 추가 (`:6543` 감지 시 명시적 실패)
- `docs/infrastructure/ENV_MANAGEMENT.md`에 migration URL 규칙(`:6543` 금지, `:5432` 사용) 반영
- `infra/docs/env-contract.md`에 동일 규칙 반영

## Type of Change

해당하는 항목에 체크해주세요:

- [x] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [x] Documentation (문서 변경)
- [x] Chore (빌드, 설정 등)

## Target Environment

배포 대상 브랜치를 선택해주세요:

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

관련 이슈를 연결해주세요:

- Closes #231

## Testing

테스트 방법을 작성해주세요:

- [ ] Postman/Swagger로 API 호출 확인
- [ ] 단위 테스트 통과
- [ ] E2E 테스트 통과

실행 내역:

- `pnpm exec prettier --check ".github/workflows/deploy-dev.yml" ".github/workflows/deploy.yml" "docs/infrastructure/ENV_MANAGEMENT.md" "infra/docs/env-contract.md"`

## Checklist

PR 생성 전 확인사항:

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [ ] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [ ] 로컬에서 린트가 통과합니다 (`pnpm run lint`)
- [ ] (API 변경 시) Swagger 문서가 업데이트되었습니다
- [ ] (필요 시) 테스트 코드를 작성했습니다

## Screenshots (Optional)

N/A

## Additional Notes

- 이번 변경은 Terraform 리소스/상태 변경이 아닌 GitHub Actions workflow 및 운영 문서 정합화 작업입니다.
- 실제 해결을 위해서는 GitHub Secret `SUPABASE_DEV_DB_URL`/`SUPABASE_PROD_DB_URL` 값을 migration-safe `:5432` 경로로 유지해야 합니다.
