### PR TITLE
Fix: 결제 취소 502 에러 수정 - REQUESTED 상태 분기 처리 (#148)

### DIFF
--- a/src/modules/payment/application/facades/payment.facade.ts
+++ b/src/modules/payment/application/facades/payment.facade.ts
@@ -70,20 +70,26 @@ export class PaymentFacade {
             return payment;
         }
 
-        try {
-            await this.payAppClient.requestCancel(payment.mulNo, 'user_requested', {
-                paymentId,
-                currentStatus: payment.status,
-            });
-        } catch (error) {
-            this.logger.error(
-                `Cancel payment external call failed: paymentId=${paymentId}, mulNo=${payment.mulNo}, status=${payment.status}, userId=${userId}`
-            );
-            throw error;
+        if (payment.status === PaymentStatus.PAID) {
+            try {
+                await this.payAppClient.requestCancel(payment.mulNo, 'user_requested', {
+                    paymentId,
+                    currentStatus: payment.status,
+                });
+            } catch (error) {
+                this.logger.error(
+                    `Cancel payment external call failed: paymentId=${paymentId}, mulNo=${payment.mulNo}, status=${payment.status}, userId=${userId}`
+                );
+                throw error;
+            }
         }
 
         const cancelledPayment = await this.paymentService.markCancelled(payment);
-        await this.ticketService.revokeAvailableTicketsForPayment(cancelledPayment.id);
+
+        if (payment.status === PaymentStatus.PAID) {
+            await this.ticketService.revokeAvailableTicketsForPayment(cancelledPayment.id);
+        }
+
         return cancelledPayment;
     }
 }

--- a/src/modules/payment/application/services/payment.service.ts
+++ b/src/modules/payment/application/services/payment.service.ts
@@ -155,7 +155,7 @@ export class PaymentService {
             return payment;
         }
 
-        if (payment.status !== PaymentStatus.PAID) {
+        if (payment.status !== PaymentStatus.PAID && payment.status !== PaymentStatus.REQUESTED) {
             throw new BusinessException(ErrorCode.PAYMENT_CANCEL_NOT_ALLOWED);
         }
 


### PR DESCRIPTION
## Summary

`POST /payments/:paymentId/cancel` 호출 시 REQUESTED 상태(미결제)의 결제건도 PayApp API에 취소 요청을 보내 502 Cloudflare HTML 응답이 발생하던 문제를 수정합니다.

## Changes

- `PaymentFacade.cancelPayment()`: 결제 상태별 분기 처리
  - `CANCELLED`: 멱등하게 즉시 반환 (기존 유지)
  - `REQUESTED`: PayApp API 호출 없이 바로 CANCELLED 처리 (미결제이므로 취소할 외부 결제 없음)
  - `PAID`: PayApp API 취소 요청 후 CANCELLED 처리 + 티켓 회수
- `PaymentService.markCancelled()`: `REQUESTED` 상태에서도 취소 허용 (기존에는 `PAID`만 허용)

### 취소 플로우 (수정 후)

```
CANCELLED → 멱등 반환 (PayApp 호출 X, 티켓 회수 X)
REQUESTED → DB만 CANCELLED 처리 (PayApp 호출 X, 티켓 회수 X)
PAID      → PayApp 취소 API 호출 → DB CANCELLED 처리 → 티켓 회수
기타       → PAYMENT_CANCEL_NOT_ALLOWED 에러
```

## Type of Change

- [x] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [ ] Documentation (문서 변경)
- [ ] Chore (빌드, 설정 등)

## Target Environment

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

- Closes #148

## Testing

- [ ] REQUESTED 상태 결제 취소 → 200 OK + CANCELLED 상태 확인 (PayApp 미호출)
- [ ] PAID 상태 결제 취소 → PayApp API 호출 후 200 OK + CANCELLED 상태 확인
- [ ] CANCELLED 상태 결제 취소 → 멱등 200 OK 확인
- [ ] WAITING/REFUNDED 상태 결제 취소 → PAYMENT_CANCEL_NOT_ALLOWED 에러 확인

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint`)
- [x] (API 변경 시) Swagger 문서가 업데이트되었습니다
- [ ] (필요 시) 테스트 코드를 작성했습니다

## Screenshots

N/A

## Additional Notes

- PayApp 자격증명(teamie0701 → teamie297jb)은 별도로 .env.dev, .env.prod, gcloud secret manager에서 업데이트 완료
- 502의 근본 원인은 2가지: (1) 만료된 PayApp 계정 자격증명 (2) REQUESTED 상태에서 불필요한 PayApp API 호출. 이 PR은 (2)를 해결