### PR TITLE
Fix: upstash 드라이버 사용 시 REDIS_HOST 검증 순서 버그 수정 (#248)

### DIFF
--- a/src/config/redis-config.ts
+++ b/src/config/redis-config.ts
@@ -63,17 +63,17 @@ export class RedisConfigService {
             return;
         }
 
+        if (driver === 'upstash') {
+            this.validateUpstashConfig();
+            return;
+        }
+
         const host = this.configService.get<string>('REDIS_HOST', DEFAULT_REDIS_HOST);
         if (LOCAL_REDIS_HOSTS.has(host)) {
             throw new Error(
                 `${profile} 프로필에서 REDIS_HOST=${host} 는 허용되지 않습니다. ` +
                     '로컬 전용 값이므로 Upstash(REST) 또는 원격 Redis 엔드포인트를 사용하세요.'
             );
-        }
-
-        if (driver === 'upstash') {
-            this.validateUpstashConfig();
-            return;
         }
     }
 


### PR DESCRIPTION
## Summary

CD 배포 실패 원인을 수정합니다. Secret Manager에서 불필요한 `REDIS_HOST` 환경변수 삭제 후 앱이 시작되지 않는 버그입니다.

## Changes

- `validateProfileRedisRouting()`에서 upstash 드라이버 early return을 REDIS_HOST localhost 검증보다 먼저 수행하도록 순서 변경

## Type of Change

- [x] Bug fix (기존 기능을 수정하는 변경)

## Target Environment

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

- Related to #248

## Testing

- [ ] dev 환경 CD 배포 성공 확인

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint`)

## Screenshots

N/A

## Additional Notes

**원인**: Secret Manager v17에서 `REDIS_HOST` 등 Redis 키 삭제 → `validateProfileRedisRouting()`에서 기본값 `localhost` → dev 프로필에서 localhost 금지 에러 → 앱 크래시 루프. upstash 분기가 이 체크보다 뒤에 있어서 발생.