### PR TITLE
Fix: EventModule 순환 참조 해결 (#248)

### DIFF
--- a/src/modules/event/event.module.ts
+++ b/src/modules/event/event.module.ts
@@ -13,14 +13,13 @@ import { EventController } from './presentation/event.controller';
 import { EventRewardFacade } from './application/facades/event-reward.facade';
 import { UserModule } from '../user/user.module';
 import { TicketModule } from '../ticket/ticket.module';
-import { InternalModule } from '../internal/internal.module';
+import { InternalApiKeyGuard } from '../internal/infrastructure/guards/internal-api-key.guard';
 
 @Module({
     imports: [
         TypeOrmModule.forFeature([Event, EventParticipation, EventFeedbackSubmission]),
         UserModule,
         TicketModule,
-        InternalModule,
     ],
     controllers: [EventController],
     providers: [
@@ -31,6 +30,7 @@ import { InternalModule } from '../internal/internal.module';
         EventParticipationService,
         EventFeedbackSubmissionService,
         EventRewardFacade,
+        InternalApiKeyGuard,
     ],
     exports: [
         EventService,


### PR DESCRIPTION
## Summary

CD 배포 실패의 직접적 원인인 순환 참조를 수정합니다.

## Changes

- `EventModule`에서 `InternalModule` import 제거
- `InternalApiKeyGuard`를 `EventModule`의 provider로 직접 등록 (Guard는 `ConfigService`(Global)만 의존하므로 모듈 import 불필요)

## Type of Change

- [x] Bug fix (기존 기능을 수정하는 변경)

## Target Environment

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

- Related to #248

## Testing

- [ ] dev 환경 CD 배포 성공 확인
- [ ] 기존 `POST /events/admin/:eventCode/feedback-rewards/grants` API가 InternalApiKeyGuard로 보호되는지 확인

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint`)

## Screenshots

N/A

## Additional Notes

순환 참조 경로: `EventModule → InternalModule → InsightModule → ... → EventModule`
에러: `ReferenceError: Cannot access 'InsightModule' before initialization`