### PR TITLE
Fix: phoneNum nullable 컬럼 SWC 타입 에러 수정 (#248)

### DIFF
--- a/src/modules/event/domain/entities/event-feedback-submission.entity.ts
+++ b/src/modules/event/domain/entities/event-feedback-submission.entity.ts
@@ -25,7 +25,7 @@ export class EventFeedbackSubmission extends BaseEntity {
     @Column({ name: 'user_id', type: 'int', nullable: true })
     userId: number | null;
 
-    @Column({ name: 'phone_num', length: 20, nullable: true })
+    @Column({ name: 'phone_num', type: 'varchar', length: 20, nullable: true })
     phoneNum: string | null;
 
     @Column({


### PR DESCRIPTION
## Summary

SWC 컴파일러 환경에서 `string | null` union type이 `Object`로 emit되어 TypeORM이 `Data type "Object" not supported` 에러를 발생시키는 문제를 수정합니다.

## Changes

- `EventFeedbackSubmission.phoneNum` `@Column`에 `type: 'varchar'` 명시적 지정

## Type of Change

- [x] Bug fix (기존 기능을 수정하는 변경)

## Target Environment

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

- Related to #248

## Testing

- [ ] dev 환경 CD 배포 성공 확인

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint`)

## Screenshots

N/A

## Additional Notes

SWC는 TypeScript union type(`string | null`)의 design:type 메타데이터를 `Object`로 emit합니다. TypeORM은 이를 DB 타입으로 매핑하지 못해 에러를 발생시킵니다. `@Column({ type: 'varchar' })`를 명시하면 메타데이터 대신 직접 지정한 타입을 사용합니다.