### PR TITLE
Fix: 포트폴리오 선택 시 INTERNAL 타입 누락 버그 수정 (#266)

### DIFF
--- a/src/modules/portfolio-correction/application/facades/external-portfolio.facade.ts
+++ b/src/modules/portfolio-correction/application/facades/external-portfolio.facade.ts
@@ -48,7 +48,7 @@ export class ExternalPortfolioFacade {
             return [];
         }
 
-        const portfolios = await this.externalPortfolioService.getExternalPortfolios(portfolioIds);
+        const portfolios = await this.externalPortfolioService.getPortfolios(portfolioIds);
         return portfolios.map((portfolio) => StructuredPortfolioResDTO.from(portfolio));
     }
 
@@ -75,7 +75,7 @@ export class ExternalPortfolioFacade {
         const activePortfolios =
             activePortfolioIds.length === 0
                 ? []
-                : await this.externalPortfolioService.getExternalPortfoliosByOwnerOrThrow(
+                : await this.externalPortfolioService.getPortfoliosByOwnerOrThrow(
                       activePortfolioIds,
                       userId
                   );

--- a/src/modules/portfolio-correction/application/facades/portfolio-correction.facade.ts
+++ b/src/modules/portfolio-correction/application/facades/portfolio-correction.facade.ts
@@ -83,7 +83,7 @@ export class PortfolioCorrectionFacade {
             });
         }
 
-        const portfolios = await this.externalPortfolioService.getExternalPortfoliosByOwnerOrThrow(
+        const portfolios = await this.externalPortfolioService.getPortfoliosByOwnerOrThrow(
             activePortfolioIds,
             userId
         );
@@ -124,7 +124,7 @@ export class PortfolioCorrectionFacade {
             throw new BusinessException(ErrorCode.CORRECTION_BLOCK_LIMIT_EXCEEDED);
         }
 
-        const portfolios = await this.externalPortfolioService.getExternalPortfoliosByOwnerOrThrow(
+        const portfolios = await this.externalPortfolioService.getPortfoliosByOwnerOrThrow(
             uniqueIds,
             userId
         );

--- a/src/modules/portfolio/application/services/external-portfolio.service.ts
+++ b/src/modules/portfolio/application/services/external-portfolio.service.ts
@@ -36,6 +36,22 @@ export class ExternalPortfolioService {
         return portfolios;
     }
 
+    async getPortfoliosByOwnerOrThrow(
+        portfolioIds: number[],
+        userId: number
+    ): Promise<Portfolio[]> {
+        const uniqueIds = [...new Set(portfolioIds)];
+        const portfolios = await this.portfolioRepository.findByIdsAndUserId(uniqueIds, userId);
+        if (portfolios.length !== uniqueIds.length) {
+            throw new BusinessException(ErrorCode.PORTFOLIO_NOT_FOUND);
+        }
+        return portfolios;
+    }
+
+    async getPortfolios(portfolioIds: number[]): Promise<Portfolio[]> {
+        return this.portfolioRepository.findByIds(portfolioIds);
+    }
+
     async createEmptyPortfolio(userId: number): Promise<Portfolio> {
         const portfolio = Portfolio.createExternal(userId);
         return this.portfolioRepository.save(portfolio);

--- a/src/modules/portfolio/infrastructure/repositories/portfolio.repository.ts
+++ b/src/modules/portfolio/infrastructure/repositories/portfolio.repository.ts
@@ -66,6 +66,25 @@ export class PortfolioRepository {
         });
     }
 
+    async findByIdsAndUserId(ids: number[], userId: number): Promise<Portfolio[]> {
+        if (ids.length === 0) return [];
+        return this.portfolioRepository.find({
+            where: {
+                id: In(ids),
+                user: { id: userId },
+            },
+        });
+    }
+
+    async findByIds(ids: number[]): Promise<Portfolio[]> {
+        if (ids.length === 0) return [];
+        return this.portfolioRepository.find({
+            where: {
+                id: In(ids),
+            },
+        });
+    }
+
     async findAllCompletedByUserId(userId: number): Promise<Portfolio[]> {
         return this.portfolioRepository.find({
             where: {


### PR DESCRIPTION
## Summary

POST `/portfolio-corrections/{correctionId}/select` API에서 텍스트형(INTERNAL) 포트폴리오를 선택할 때 `PORTFOLIO_NOT_FOUND` 에러가 발생하는 버그를 수정합니다.

## Changes

- `PortfolioRepository`에 `sourceType` 필터 없는 범용 조회 메서드 추가 (`findByIdsAndUserId`, `findByIds`)
- `ExternalPortfolioService`에 범용 조회 메서드 추가 (`getPortfoliosByOwnerOrThrow`, `getPortfolios`)
- `PortfolioCorrectionFacade`의 `resolveSelectionTargets`, `selectAndGenerate`에서 EXTERNAL 전용 조회를 범용 조회로 교체
- `ExternalPortfolioFacade`의 `getExternalPortfolios`, `createExternalPortfolioBlock`에서 EXTERNAL 전용 조회를 범용 조회로 교체

## Type of Change

- [x] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [ ] Documentation (문서 변경)
- [ ] Chore (빌드, 설정 등)

## Target Environment

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

- Closes #266

## Testing

- [x] Postman/Swagger로 API 호출 확인
  - 텍스트형 포트폴리오 생성 후 `POST /portfolio-corrections/{correctionId}/select`에서 정상 연결 확인 필요
  - PDF 포트폴리오 선택도 기존과 동일하게 동작하는지 확인 필요
- [ ] 단위 테스트 통과
- [ ] E2E 테스트 통과

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint`)
- [ ] (API 변경 시) Swagger 문서가 업데이트되었습니다
- [ ] (필요 시) 테스트 코드를 작성했습니다

## Screenshots (Optional)

N/A

## Additional Notes

- 근본 원인: 첨삭 포트폴리오 선택 흐름에서 `sourceType: EXTERNAL` 필터가 하드코딩되어 있어 경험 정리 기반 텍스트형(`INTERNAL`) 포트폴리오가 조회에서 누락됨
- 영향 범위: `select`, `generate`, 선택된 포트폴리오 조회, PDF 블록 추가 시 기존 선택 유지 — 총 4곳 수정
- 후속 작업: #269 에서 네이밍/책임 분리 리팩토링 예정