### PR TITLE
Fix: Admin 이벤트 보상 지급 모달 레이아웃 깨짐 수정 (#299)

### DIFF
--- a/admin-client/assets/components/Modal.js
+++ b/admin-client/assets/components/Modal.js
@@ -578,7 +578,7 @@ export function GrantEventRewardModal({ open, user, eventOptions, onClose, onSuc
     `;
 
     return html`
-        <${Modal} open=${open} onClose=${onClose}>
+        <${Modal} open=${open} onClose=${onClose} panelClassName="max-w-5xl">
             ${step === 'form' ? formView : confirmView}
         <//>
     `;


### PR DESCRIPTION
## Summary

Admin 이벤트 보상 지급 모달(`GrantEventRewardModal`)에 `panelClassName`이 누락되어 기본값 `max-w-md`(448px)가 적용되면서 2열 그리드 레이아웃이 깨지는 버그를 수정합니다.

## Changes

- `GrantEventRewardModal`의 `Modal` 컴포넌트에 `panelClassName="max-w-5xl"` 추가
- `GrantTicketModal`과 동일한 모달 너비로 통일

## Type of Change

- [x] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [ ] Documentation (문서 변경)
- [ ] Chore (빌드, 설정 등)

## Target Environment

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

- Closes #299

## Testing

- [x] Dev 서버에서 Admin 대시보드 접속 후 이벤트 보상 지급 모달 레이아웃 정상 확인

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint`)
- [ ] (API 변경 시) Swagger 문서가 업데이트되었습니다
- [ ] (필요 시) 테스트 코드를 작성했습니다

## Screenshots

N/A

## Additional Notes

`GrantTicketModal`은 이미 `panelClassName="max-w-5xl"`을 사용하고 있었으나, `GrantEventRewardModal`만 누락된 상태였습니다. 1줄 변경으로 해결됩니다.