### PR TITLE
Fix: 마이그레이션 enum 정리 멱등성 보장 (#327)

### DIFF
--- a/supabase/migrations/20260311000000_cleanup_unused_columns_and_tables.sql
+++ b/supabase/migrations/20260311000000_cleanup_unused_columns_and_tables.sql
@@ -20,18 +20,26 @@ ALTER TABLE "event_participation" DROP COLUMN IF EXISTS "last_progressed_at";
 ALTER TABLE "event_participation" DROP COLUMN IF EXISTS "granted_by";
 ALTER TABLE "event_participation" DROP COLUMN IF EXISTS "grant_reason";
 
--- 5. Remove unused enum values from event_reward_status
--- PostgreSQL doesn't support DROP VALUE from enum directly.
--- Create new enum, migrate column, drop old enum.
-ALTER TYPE "event_participation_reward_status_enum"
-    RENAME TO "event_participation_reward_status_enum_old";
+-- 5. Remove unused enum values from event_reward_status (idempotent)
+DO $$
+BEGIN
+    -- Only run if old enum still has UNDER_REVIEW (i.e., not yet migrated)
+    IF EXISTS (
+        SELECT 1 FROM pg_enum
+        WHERE enumlabel = 'UNDER_REVIEW'
+        AND enumtypid = 'event_participation_reward_status_enum'::regtype
+    ) THEN
+        ALTER TYPE "event_participation_reward_status_enum"
+            RENAME TO "event_participation_reward_status_enum_old";
 
-CREATE TYPE "event_participation_reward_status_enum" AS ENUM ('NOT_GRANTED', 'GRANTED');
+        CREATE TYPE "event_participation_reward_status_enum" AS ENUM ('NOT_GRANTED', 'GRANTED');
 
-ALTER TABLE "event_participation"
-    ALTER COLUMN "reward_status" DROP DEFAULT,
-    ALTER COLUMN "reward_status" TYPE "event_participation_reward_status_enum"
-        USING "reward_status"::text::"event_participation_reward_status_enum",
-    ALTER COLUMN "reward_status" SET DEFAULT 'NOT_GRANTED';
+        ALTER TABLE "event_participation"
+            ALTER COLUMN "reward_status" DROP DEFAULT,
+            ALTER COLUMN "reward_status" TYPE "event_participation_reward_status_enum"
+                USING "reward_status"::text::"event_participation_reward_status_enum",
+            ALTER COLUMN "reward_status" SET DEFAULT 'NOT_GRANTED';
 
-DROP TYPE "event_participation_reward_status_enum_old";
+        DROP TYPE "event_participation_reward_status_enum_old";
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary

#328 에서 누락된 마이그레이션 멱등성 처리를 보완합니다.

## Changes

- enum 교체 로직(`ALTER TYPE ... RENAME TO`)이 CI/CD에서 재실행 시 실패하는 문제 수정
- `UNDER_REVIEW` 값 존재 여부를 확인한 후에만 enum 교체 실행하도록 `DO $$ ... END $$` 블록으로 래핑

## Type of Change

- [x] Bug fix (기존 기능을 수정하는 변경)

## Target Environment

- [x] Dev (`dev`)

## Related Issues

- Closes #327

## Testing

- [x] 이미 적용된 Dev/Prod DB에서 재실행 시 에러 없음 확인

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [x] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint`)

## Screenshots (Optional)

N/A

## Additional Notes

N/A