### PR TITLE
Fix: PayApp 웹훅 전역 ValidationPipe 우회 (#347)

### DIFF
--- a/src/modules/payment/presentation/payment.controller.ts
+++ b/src/modules/payment/presentation/payment.controller.ts
@@ -1,5 +1,4 @@
 import {
-    Body,
     Controller,
     Get,
     HttpCode,
@@ -8,8 +7,8 @@ import {
     Param,
     ParseIntPipe,
     Post,
-    UsePipes,
-    ValidationPipe,
+    Req,
+    Body,
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { ApiCommonErrorResponse, ApiCommonResponse } from 'src/common/decorators/swagger.decorator';
@@ -24,6 +23,8 @@ import {
     PayAppWebhookReqDTO,
     PaymentResDTO,
 } from '../application/dtos/payment.dto';
+import { plainToInstance } from 'class-transformer';
+import type { Request } from 'express';
 
 @ApiTags('Payment')
 @Controller('payments')
@@ -73,7 +74,6 @@ export class PaymentController {
     @Post('webhook')
     @Public()
     @SkipTransform()
-    @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
     @ApiOperation({
         summary: 'PayApp 결제 콜백(feedbackurl) 수신',
         description:
@@ -81,7 +81,11 @@ export class PaymentController {
     })
     @ApiCommonErrorResponse(ErrorCode.PAYMENT_NOT_FOUND, ErrorCode.PAYMENT_WEBHOOK_INVALID)
     @HttpCode(HttpStatus.OK)
-    async handleWebhook(@Body() dto: PayAppWebhookReqDTO): Promise<string> {
+    async handleWebhook(@Req() req: Request): Promise<string> {
+        const dto = plainToInstance(PayAppWebhookReqDTO, req.body, {
+            enableImplicitConversion: true,
+        });
+
         try {
             await this.paymentFacade.handleWebhook(dto);
         } catch (error) {


### PR DESCRIPTION
## Summary

이전 수정(`@UsePipes`)이 전역 ValidationPipe를 override하지 못하는 문제 해결. `@Body()` → `@Req()` + `plainToInstance()`로 전역 파이프를 완전 우회.

## Changes

- `handleWebhook()`: `@Body() dto` → `@Req() req` + `plainToInstance()`로 수동 변환
- `@UsePipes`, `ValidationPipe` import 제거

## Type of Change

- [x] Bug fix (기존 기능을 수정하는 변경)

## Target Environment

- [x] Dev (`dev`)

## Related Issues

- Closes #347

## Testing

- [ ] Dev 배포 후 실제 결제 → PAID 전환 확인 필요

## Checklist

- [x] 코드 컨벤션을 준수했습니다
- [x] Git 컨벤션을 준수했습니다
- [x] 로컬에서 빌드가 성공합니다
- [x] 로컬에서 린트가 통과합니다

## Additional Notes

NestJS `app.useGlobalPipes()`로 등록된 전역 파이프는 `@UsePipes()`로 override 불가 — 누적 실행됨. `@Req()`는 파이프 체인을 거치지 않으므로 `forbidNonWhitelisted` 영향 없이 PayApp의 추가 필드를 허용.