### PR TITLE
Fix: PayApp mulNo 매핑 수정 — 웹훅 수신 시 결제 조회 실패 해결 (#347)

### DIFF
--- a/src/modules/payment/application/facades/payment.facade.ts
+++ b/src/modules/payment/application/facades/payment.facade.ts
@@ -34,12 +34,11 @@ export class PaymentFacade {
         );
 
         try {
-            const payUrl = await this.payAppClient.requestPayment({
-                mulNo: payment.mulNo,
+            const { payUrl, mulNo } = await this.payAppClient.requestPayment({
                 price: payment.amount,
                 goodname: ticketProduct.getDisplayName(),
             });
-            return this.paymentService.savePayUrl(payment, payUrl);
+            return this.paymentService.savePayResult(payment, payUrl, mulNo);
         } catch (error) {
             await this.paymentService.markCancelled(payment);
             throw error;

--- a/src/modules/payment/application/services/payment.service.ts
+++ b/src/modules/payment/application/services/payment.service.ts
@@ -150,8 +150,11 @@ export class PaymentService {
         return payState === PAYAPP_PAY_STATE_PAID;
     }
 
-    async savePayUrl(payment: Payment, payUrl: string): Promise<Payment> {
+    async savePayResult(payment: Payment, payUrl: string, mulNo: number): Promise<Payment> {
         payment.payUrl = payUrl;
+        if (mulNo > 0) {
+            payment.mulNo = mulNo;
+        }
         return this.paymentRepository.save(payment);
     }
 

--- a/src/modules/payment/infrastructure/clients/payapp.client.ts
+++ b/src/modules/payment/infrastructure/clients/payapp.client.ts
@@ -119,10 +119,9 @@ export class PayAppClient {
     }
 
     async requestPayment(params: {
-        mulNo: number;
         price: number;
         goodname: string;
-    }): Promise<string> {
+    }): Promise<{ payUrl: string; mulNo: number }> {
         if (!this.userId || !this.linkKey || !this.feedbackUrl) {
             this.logger.error(
                 'PayApp requestPayment: missing config (userId, linkKey, or feedbackUrl)'
@@ -136,7 +135,6 @@ export class PayAppClient {
             linkkey: this.linkKey,
             goodname: params.goodname,
             price: String(params.price),
-            mul_no: String(params.mulNo),
             feedbackurl: this.feedbackUrl,
             recvphone: '01000000000',
             smsuse: 'n',
@@ -154,7 +152,7 @@ export class PayAppClient {
             const kind: RequestFailureKind =
                 error instanceof Error && error.name === 'TimeoutError' ? 'TIMEOUT' : 'NETWORK';
             this.logger.error(
-                `PayApp request ${kind}: mulNo=${params.mulNo}, error=${error instanceof Error ? error.message : String(error)}`,
+                `PayApp request ${kind}: price=${params.price}, error=${error instanceof Error ? error.message : String(error)}`,
                 error instanceof Error ? error.stack : undefined
             );
             throw this.buildRequestFailure(kind);
@@ -162,7 +160,7 @@ export class PayAppClient {
 
         if (!response.ok) {
             this.logger.warn(
-                `PayApp request HTTP_ERROR: mulNo=${params.mulNo}, httpStatus=${response.status}`
+                `PayApp request HTTP_ERROR: price=${params.price}, httpStatus=${response.status}`
             );
             throw this.buildRequestFailure('HTTP_ERROR', response.status);
         }
@@ -172,37 +170,40 @@ export class PayAppClient {
             text = (await response.text()).trim();
         } catch (error) {
             this.logger.error(
-                `PayApp request RESPONSE_READ_FAILED: mulNo=${params.mulNo}, error=${error instanceof Error ? error.message : String(error)}`,
+                `PayApp request RESPONSE_READ_FAILED: price=${params.price}, error=${error instanceof Error ? error.message : String(error)}`,
                 error instanceof Error ? error.stack : undefined
             );
             throw this.buildRequestFailure('RESPONSE_READ_FAILED');
         }
 
-        const payUrl = this.extractPayUrl(text);
-        if (!payUrl) {
+        const result = this.parsePayResponse(text);
+        if (!result) {
             this.logger.warn(
-                `PayApp request REJECTED: mulNo=${params.mulNo}, response=${text.slice(0, 200)}`
+                `PayApp request REJECTED: price=${params.price}, response=${text.slice(0, 200)}`
             );
             throw this.buildRequestFailure('REJECTED');
         }
 
-        return payUrl;
+        return result;
     }
 
-    private extractPayUrl(text: string): string | null {
-        // PayApp returns 'payurl=' (without underscore)
-        const match = /payurl=([^\s&]+)/.exec(text);
-        if (match) {
-            try {
-                return decodeURIComponent(match[1]);
-            } catch {
-                return match[1];
-            }
+    private parsePayResponse(text: string): { payUrl: string; mulNo: number } | null {
+        const urlMatch = /payurl=([^\s&]+)/.exec(text);
+        const mulNoMatch = /(?:^|&)mul_no=(\d+)/.exec(text);
+
+        if (!urlMatch) {
+            return null;
         }
-        if (text.startsWith('https://')) {
-            return text;
+
+        let payUrl: string;
+        try {
+            payUrl = decodeURIComponent(urlMatch[1]);
+        } catch {
+            payUrl = urlMatch[1];
         }
-        return null;
+
+        const mulNo = mulNoMatch ? Number(mulNoMatch[1]) : 0;
+        return { payUrl, mulNo };
     }
 
     private buildRequestFailure(kind: RequestFailureKind, httpStatus?: number): BusinessException {


### PR DESCRIPTION
## Summary

PayApp이 자체 할당하는 `mul_no`와 우리가 생성한 `mul_no`가 달라서 웹훅 수신 시 결제를 못 찾는 문제 해결

## Changes

- `PayAppClient.requestPayment()`: PayApp 응답에서 `mul_no` 추출하여 반환
- `parsePayResponse()`: `payUrl` + `mulNo` 동시 추출
- `PaymentService.savePayResult()`: `payUrl` + PayApp `mulNo` 동시 저장
- `PaymentFacade.createPayment()`: 구조분해 할당으로 결과 처리

## Type of Change

- [x] Bug fix (기존 기능을 수정하는 변경)

## Target Environment

- [x] Dev (`dev`)

## Related Issues

- Closes #347

## Testing

- [x] 로컬 테스트: 추가 필드 포함 form-urlencoded 웹훅 → PAID 전환 + 티켓 3장 발급 확인

## Checklist

- [x] 코드 컨벤션을 준수했습니다
- [x] Git 컨벤션을 준수했습니다
- [x] 로컬에서 빌드가 성공합니다
- [x] 로컬에서 린트가 통과합니다

## Additional Notes

**근본 원인**: 우리가 보낸 `mul_no=1774166556`과 PayApp이 응답에서 할당한 `mul_no=114274325`가 서로 달랐음. 웹훅은 PayApp의 `mul_no`로 오는데 DB에는 우리 값이 저장돼서 `findByMulNoOrThrow()` 실패.