### PR TITLE
Fix: PayApp 결제 취소 paycancelreq → paycancel 변경 (#347)

### DIFF
--- a/src/modules/payment/infrastructure/clients/payapp.client.ts
+++ b/src/modules/payment/infrastructure/clients/payapp.client.ts
@@ -69,7 +69,7 @@ export class PayAppClient {
             : `mulNo=${mulNo}`;
 
         const body = new URLSearchParams({
-            cmd: 'paycancelreq',
+            cmd: 'paycancel',
             userid: this.userId,
             linkkey: this.linkKey,
             mul_no: String(mulNo),
@@ -112,7 +112,7 @@ export class PayAppClient {
             throw this.cancelFailure('RESPONSE_READ_FAILED', mulNo, context);
         }
 
-        if (!text.startsWith('OK')) {
+        if (!text.includes('state=1') && !text.startsWith('OK')) {
             this.logger.warn(`PayApp cancel REJECTED: ${logCtx}, response=${text.slice(0, 200)}`);
             throw this.cancelFailure('REJECTED', mulNo, context);
         }


### PR DESCRIPTION
## Summary

최근 결제된 건의 취소가 실패하는 문제 수정

## Changes

- `PayAppClient.requestCancel()`: `cmd=paycancelreq` → `cmd=paycancel` 변경
- 응답 성공 판정에 `state=1` 체크 추가 (`paycancel` 응답 형식 대응)

## Type of Change

- [x] Bug fix (기존 기능을 수정하는 변경)

## Target Environment

- [x] Dev (`dev`)

## Related Issues

- Closes #347

## Testing

- [x] PayApp API 직접 호출로 `paycancel` 정상 취소 확인 완료

## Checklist

- [x] 코드 컨벤션을 준수했습니다
- [x] Git 컨벤션을 준수했습니다
- [x] 로컬에서 린트가 통과합니다

## Additional Notes

- `paycancelreq`: D+5일 경과 또는 정산 완료 후에만 동작 → 최근 결제 취소 불가
- `paycancel`: 즉시 취소 → 최근 결제 취소 가능
- `paycancel` 응답은 `state=1`로 성공 표시 (`OK`가 아님)