### PR TITLE
Feat: POST /slide-plan 응답에 저장된 슬라이드 목록 반환

### DIFF
--- a/src/modules/internal/application/dtos/internal-visualization.dto.ts
+++ b/src/modules/internal/application/dtos/internal-visualization.dto.ts
@@ -8,8 +8,38 @@ import {
     MaxLength,
     Min,
     ValidateNested,
+    registerDecorator,
+    ValidationArguments,
+    ValidationOptions,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+
+function IsArrayLengthEqualTo(property: string, validationOptions?: ValidationOptions) {
+    return (object: object, propertyName: string) => {
+        registerDecorator({
+            name: 'isArrayLengthEqualTo',
+            target: object.constructor,
+            propertyName,
+            constraints: [property],
+            options: validationOptions,
+            validator: {
+                validate(value: unknown, args: ValidationArguments): boolean {
+                    const [relatedProp] = args.constraints as string[];
+                    const relatedValue = (args.object as Record<string, unknown>)[relatedProp];
+                    return (
+                        Array.isArray(value) &&
+                        typeof relatedValue === 'number' &&
+                        value.length === relatedValue
+                    );
+                },
+                defaultMessage(args: ValidationArguments): string {
+                    const [relatedProp] = args.constraints as string[];
+                    return `${args.property} 배열 길이는 ${relatedProp}과 일치해야 합니다.`;
+                },
+            },
+        });
+    };
+}
 import {
     VisualizationJob,
     SlidePlan,
@@ -91,6 +121,7 @@ export class SaveSlidePlanReqDTO {
     @ApiProperty({ description: '슬라이드 플랜 JSON (§10.2 slide_plan)' })
     slidePlan: Record<string, unknown>;
 
+    @IsArrayLengthEqualTo('totalSlides')
     @IsArray()
     @ValidateNested({ each: true })
     @Type(() => SlideItemReqDTO)

--- a/src/modules/internal/application/dtos/internal-visualization.dto.ts
+++ b/src/modules/internal/application/dtos/internal-visualization.dto.ts
@@ -22,6 +22,40 @@ import {
 } from 'src/modules/visualization/domain/visualization-slide.entity';
 import { VisualizationSlideStatus } from 'src/modules/visualization/domain/enums/visualization-slide-status.enum';
 
+export class SaveSlidePlanSlideItemResDTO {
+    @ApiProperty({ description: '슬라이드 UUID' })
+    id: string;
+
+    @ApiProperty({ description: '슬라이드 순서 (1-indexed)' })
+    slideOrder: number;
+
+    @ApiProperty({ description: '소스 슬라이드 ID' })
+    sourceSlideId: string;
+
+    @ApiProperty({ description: '슬라이드 XML 파일명' })
+    slideFilename: string;
+
+    static from(slide: VisualizationSlide): SaveSlidePlanSlideItemResDTO {
+        const dto = new SaveSlidePlanSlideItemResDTO();
+        dto.id = slide.id;
+        dto.slideOrder = slide.slideOrder;
+        dto.sourceSlideId = slide.sourceSlideId;
+        dto.slideFilename = slide.slideFilename;
+        return dto;
+    }
+}
+
+export class SaveSlidePlanResDTO {
+    @ApiProperty({ type: [SaveSlidePlanSlideItemResDTO] })
+    slides: SaveSlidePlanSlideItemResDTO[];
+
+    static from(slides: VisualizationSlide[]): SaveSlidePlanResDTO {
+        const dto = new SaveSlidePlanResDTO();
+        dto.slides = slides.map((s) => SaveSlidePlanSlideItemResDTO.from(s));
+        return dto;
+    }
+}
+
 export class SlideItemReqDTO {
     @IsInt()
     @Min(1)

--- a/src/modules/internal/application/facades/internal-visualization.facade.spec.ts
+++ b/src/modules/internal/application/facades/internal-visualization.facade.spec.ts
@@ -88,15 +88,6 @@ describe('InternalVisualizationFacade', () => {
     });
 
     describe('saveSlidePlan', () => {
-        describe('입력 검증', () => {
-            it('totalSlides와 slides 배열 길이가 다르면 BAD_REQUEST를 던진다', async () => {
-                const body = makeBody({ totalSlides: 3 }); // slides는 2개
-
-                await expect(facade.saveSlidePlan(JOB_ID, body)).rejects.toThrow(BusinessException);
-                expect(findByIdOrThrow).not.toHaveBeenCalled();
-            });
-        });
-
         describe('job 검증', () => {
             it('job이 존재하지 않으면 VISUALIZATION_JOB_NOT_FOUND가 전파된다', async () => {
                 findByIdOrThrow.mockRejectedValue(

--- a/src/modules/internal/application/facades/internal-visualization.facade.spec.ts
+++ b/src/modules/internal/application/facades/internal-visualization.facade.spec.ts
@@ -68,12 +68,12 @@ describe('InternalVisualizationFacade', () => {
 
     let findByIdOrThrow: jest.Mock;
     let updateSlidePlan: jest.Mock;
-    let bulkInsert: jest.Mock;
+    let replaceSlides: jest.Mock;
 
     beforeEach(() => {
         findByIdOrThrow = jest.fn().mockResolvedValue(makeJob());
         updateSlidePlan = jest.fn();
-        bulkInsert = jest.fn().mockResolvedValue(MOCK_SLIDES);
+        replaceSlides = jest.fn().mockResolvedValue(MOCK_SLIDES);
 
         const vizJobService = {
             findByIdOrThrow,
@@ -81,7 +81,7 @@ describe('InternalVisualizationFacade', () => {
         } as unknown as VisualizationJobService;
 
         const vizSlideService = {
-            bulkInsert,
+            replaceSlides,
         } as unknown as VisualizationSlideService;
 
         facade = new InternalVisualizationFacade(vizJobService, vizSlideService);
@@ -133,12 +133,12 @@ describe('InternalVisualizationFacade', () => {
                 );
             });
 
-            it('bulkInsert를 올바른 인자로 호출한다', async () => {
+            it('replaceSlides를 올바른 인자로 호출한다', async () => {
                 const body = makeBody();
 
                 await facade.saveSlidePlan(JOB_ID, body);
 
-                expect(bulkInsert).toHaveBeenCalledWith(JOB_ID, body.slides);
+                expect(replaceSlides).toHaveBeenCalledWith(JOB_ID, body.slides);
             });
 
             it('SaveSlidePlanResDTO를 반환하며 slides 배열에 id·slideOrder·sourceSlideId·slideFilename이 담긴다', async () => {
@@ -160,13 +160,32 @@ describe('InternalVisualizationFacade', () => {
                 });
             });
 
-            it('중복 콜백이 와도 예외 없이 bulkInsert를 위임한다 (ON CONFLICT DO NOTHING은 레포 레벨 처리)', async () => {
-                const body = makeBody();
+            it('재생성 시 replaceSlides를 다시 호출하여 기존 슬라이드를 교체한다', async () => {
+                const REGEN_UUID_1 = 'cccccccc-0000-0000-0000-000000000001';
+                const regenSlides = [makeSlide(REGEN_UUID_1, 1, 'cover_C', 'slide1.xml')];
+                replaceSlides.mockResolvedValueOnce(MOCK_SLIDES).mockResolvedValueOnce(regenSlides);
 
-                await facade.saveSlidePlan(JOB_ID, body);
-                await facade.saveSlidePlan(JOB_ID, body);
+                await facade.saveSlidePlan(JOB_ID, makeBody());
+                const regenResult = await facade.saveSlidePlan(
+                    JOB_ID,
+                    makeBody({
+                        totalSlides: 1,
+                        slides: [
+                            {
+                                slideOrder: 1,
+                                sourceSlideId: 'cover_C',
+                                slideFilename: 'slide1.xml',
+                            },
+                        ],
+                    })
+                );
 
-                expect(bulkInsert).toHaveBeenCalledTimes(2);
+                expect(replaceSlides).toHaveBeenCalledTimes(2);
+                expect(regenResult.slides).toHaveLength(1);
+                expect(regenResult.slides[0]).toMatchObject({
+                    id: REGEN_UUID_1,
+                    sourceSlideId: 'cover_C',
+                });
             });
         });
     });

--- a/src/modules/internal/application/facades/internal-visualization.facade.spec.ts
+++ b/src/modules/internal/application/facades/internal-visualization.facade.spec.ts
@@ -6,8 +6,10 @@ jest.mock('typeorm-transactional', () => ({
 import { InternalVisualizationFacade } from './internal-visualization.facade';
 import { VisualizationJobService } from 'src/modules/visualization/application/services/visualization-job.service';
 import { VisualizationSlideService } from 'src/modules/visualization/application/services/visualization-slide.service';
-import { SaveSlidePlanReqDTO } from '../dtos/internal-visualization.dto';
+import { SaveSlidePlanReqDTO, SaveSlidePlanResDTO } from '../dtos/internal-visualization.dto';
 import { VisualizationJob } from 'src/modules/visualization/domain/visualization-job.entity';
+import { VisualizationSlide } from 'src/modules/visualization/domain/visualization-slide.entity';
+import { VisualizationSlideStatus } from 'src/modules/visualization/domain/enums/visualization-slide-status.enum';
 import { BusinessException } from 'src/common/exceptions/business.exception';
 import { ErrorCode } from 'src/common/exceptions/error-code.enum';
 
@@ -17,6 +19,34 @@ const TEMPLATE_ID = 'blue';
 function makeJob(overrides: Partial<VisualizationJob> = {}): VisualizationJob {
     return { id: JOB_ID, templateId: TEMPLATE_ID, ...overrides } as VisualizationJob;
 }
+
+const SLIDE_UUID_1 = 'bbbbbbbb-0000-0000-0000-000000000001';
+const SLIDE_UUID_2 = 'bbbbbbbb-0000-0000-0000-000000000002';
+
+function makeSlide(
+    id: string,
+    slideOrder: number,
+    sourceSlideId: string,
+    slideFilename: string
+): VisualizationSlide {
+    return {
+        id,
+        slideOrder,
+        sourceSlideId,
+        slideFilename,
+        status: VisualizationSlideStatus.PENDING,
+        currentFills: null,
+        gcsPreviewKey: null,
+        job: { id: JOB_ID } as VisualizationJob,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+    } as VisualizationSlide;
+}
+
+const MOCK_SLIDES: VisualizationSlide[] = [
+    makeSlide(SLIDE_UUID_1, 1, 'cover_A', 'slide1.xml'),
+    makeSlide(SLIDE_UUID_2, 2, 'intro_B', 'slide2.xml'),
+];
 
 function makeBody(overrides: Partial<SaveSlidePlanReqDTO> = {}): SaveSlidePlanReqDTO {
     return {
@@ -43,7 +73,7 @@ describe('InternalVisualizationFacade', () => {
     beforeEach(() => {
         findByIdOrThrow = jest.fn().mockResolvedValue(makeJob());
         updateSlidePlan = jest.fn();
-        bulkInsert = jest.fn();
+        bulkInsert = jest.fn().mockResolvedValue(MOCK_SLIDES);
 
         const vizJobService = {
             findByIdOrThrow,
@@ -109,6 +139,25 @@ describe('InternalVisualizationFacade', () => {
                 await facade.saveSlidePlan(JOB_ID, body);
 
                 expect(bulkInsert).toHaveBeenCalledWith(JOB_ID, body.slides);
+            });
+
+            it('SaveSlidePlanResDTO를 반환하며 slides 배열에 id·slideOrder·sourceSlideId·slideFilename이 담긴다', async () => {
+                const result = await facade.saveSlidePlan(JOB_ID, makeBody());
+
+                expect(result).toBeInstanceOf(SaveSlidePlanResDTO);
+                expect(result.slides).toHaveLength(2);
+                expect(result.slides[0]).toEqual({
+                    id: SLIDE_UUID_1,
+                    slideOrder: 1,
+                    sourceSlideId: 'cover_A',
+                    slideFilename: 'slide1.xml',
+                });
+                expect(result.slides[1]).toEqual({
+                    id: SLIDE_UUID_2,
+                    slideOrder: 2,
+                    sourceSlideId: 'intro_B',
+                    slideFilename: 'slide2.xml',
+                });
             });
 
             it('중복 콜백이 와도 예외 없이 bulkInsert를 위임한다 (ON CONFLICT DO NOTHING은 레포 레벨 처리)', async () => {

--- a/src/modules/internal/application/facades/internal-visualization.facade.ts
+++ b/src/modules/internal/application/facades/internal-visualization.facade.ts
@@ -42,7 +42,7 @@ export class InternalVisualizationFacade {
             body.totalSlides,
             body.slidePlan as unknown as SlidePlan
         );
-        const slides = await this.vizSlideService.bulkInsert(jobId, body.slides);
+        const slides = await this.vizSlideService.replaceSlides(jobId, body.slides);
 
         this.logger.log(
             `[slide-plan] DONE jobId=${jobId} idempotencyKey=${body.idempotencyKey} totalSlides=${body.totalSlides}`

--- a/src/modules/internal/application/facades/internal-visualization.facade.ts
+++ b/src/modules/internal/application/facades/internal-visualization.facade.ts
@@ -9,6 +9,7 @@ import {
     InternalVisualizationJobResDTO,
     InternalVisualizationSlideResDTO,
     SaveSlidePlanReqDTO,
+    SaveSlidePlanResDTO,
 } from '../dtos/internal-visualization.dto';
 
 @Injectable()
@@ -21,7 +22,7 @@ export class InternalVisualizationFacade {
     ) {}
 
     @Transactional()
-    async saveSlidePlan(jobId: string, body: SaveSlidePlanReqDTO): Promise<void> {
+    async saveSlidePlan(jobId: string, body: SaveSlidePlanReqDTO): Promise<SaveSlidePlanResDTO> {
         if (body.totalSlides !== body.slides.length) {
             throw new BusinessException(ErrorCode.BAD_REQUEST, {
                 reason: `totalSlides(${body.totalSlides})와 slides 배열 길이(${body.slides.length})가 일치하지 않습니다.`,
@@ -41,13 +42,15 @@ export class InternalVisualizationFacade {
             body.totalSlides,
             body.slidePlan as unknown as SlidePlan
         );
-        await this.vizSlideService.bulkInsert(jobId, body.slides);
+        const slides = await this.vizSlideService.bulkInsert(jobId, body.slides);
 
         this.logger.log(
             `[slide-plan] DONE jobId=${jobId} idempotencyKey=${body.idempotencyKey} totalSlides=${body.totalSlides}`
         );
 
         // TODO: SSE — visualizations.{jobId} 채널에 slide_plan_ready 이벤트 emit
+
+        return SaveSlidePlanResDTO.from(slides);
     }
 
     async getJob(jobId: string): Promise<InternalVisualizationJobResDTO> {

--- a/src/modules/internal/application/facades/internal-visualization.facade.ts
+++ b/src/modules/internal/application/facades/internal-visualization.facade.ts
@@ -23,12 +23,6 @@ export class InternalVisualizationFacade {
 
     @Transactional()
     async saveSlidePlan(jobId: string, body: SaveSlidePlanReqDTO): Promise<SaveSlidePlanResDTO> {
-        if (body.totalSlides !== body.slides.length) {
-            throw new BusinessException(ErrorCode.BAD_REQUEST, {
-                reason: `totalSlides(${body.totalSlides})와 slides 배열 길이(${body.slides.length})가 일치하지 않습니다.`,
-            });
-        }
-
         this.logger.log(
             `[slide-plan] START jobId=${jobId} idempotencyKey=${body.idempotencyKey} schemaVersion=${body.schemaVersion}`
         );

--- a/src/modules/internal/presentation/internal-visualization.controller.ts
+++ b/src/modules/internal/presentation/internal-visualization.controller.ts
@@ -18,6 +18,7 @@ import {
     InternalVisualizationJobResDTO,
     InternalVisualizationSlideResDTO,
     SaveSlidePlanReqDTO,
+    SaveSlidePlanResDTO,
 } from '../application/dtos/internal-visualization.dto';
 import { InternalVisualizationFacade } from '../application/facades/internal-visualization.facade';
 
@@ -90,12 +91,12 @@ export class InternalVisualizationController {
             'visualization_slides를 일괄 INSERT합니다(중복 콜백 안전). ' +
             '완료 후 `visualizations.{jobId}` 이벤트를 emit합니다.',
     })
+    @ApiResponse({ status: 200, type: SaveSlidePlanResDTO })
     @ApiCommonErrorResponse(ErrorCode.UNAUTHORIZED, ErrorCode.VISUALIZATION_JOB_NOT_FOUND)
     async saveSlidePlan(
         @Param('jobId', ParseUUIDPipe) jobId: string,
         @Body() body: SaveSlidePlanReqDTO
-    ): Promise<string> {
-        await this.internalVisualizationFacade.saveSlidePlan(jobId, body);
-        return '슬라이드 플랜이 저장되었습니다.';
+    ): Promise<SaveSlidePlanResDTO> {
+        return this.internalVisualizationFacade.saveSlidePlan(jobId, body);
     }
 }

--- a/src/modules/internal/presentation/internal-visualization.controller.ts
+++ b/src/modules/internal/presentation/internal-visualization.controller.ts
@@ -88,7 +88,7 @@ export class InternalVisualizationController {
         description:
             'AI 서버가 슬라이드 플랜 생성 완료 후 호출합니다. ' +
             'visualization_jobs의 total_slides·slide_plan을 갱신하고 ' +
-            'visualization_slides를 일괄 INSERT합니다(중복 콜백 안전). ' +
+            '기존 슬라이드를 삭제한 뒤 새 슬라이드를 일괄 INSERT합니다(재생성 대응). ' +
             '완료 후 `visualizations.{jobId}` 이벤트를 emit합니다.',
     })
     @ApiResponse({ status: 200, type: SaveSlidePlanResDTO })

--- a/src/modules/visualization/application/services/visualization-slide.service.ts
+++ b/src/modules/visualization/application/services/visualization-slide.service.ts
@@ -51,14 +51,15 @@ export class VisualizationSlideService {
         return this.vizSlideRepo.existsNonCompletedByJobId(jobId);
     }
 
-    async bulkInsert(jobId: string, slides: SlideInput[]): Promise<VisualizationSlide[]> {
+    async replaceSlides(jobId: string, slides: SlideInput[]): Promise<VisualizationSlide[]> {
+        await this.vizSlideRepo.deleteAllByJobId(jobId);
         const rows: SlideInsertRow[] = slides.map((s) => ({
             job: { id: jobId },
             slideOrder: s.slideOrder,
             sourceSlideId: s.sourceSlideId,
             slideFilename: s.slideFilename,
         }));
-        await this.vizSlideRepo.bulkInsertIgnoreConflict(rows);
+        await this.vizSlideRepo.bulkInsert(rows);
         return this.vizSlideRepo.findAllByJobId(jobId);
     }
 }

--- a/src/modules/visualization/application/services/visualization-slide.service.ts
+++ b/src/modules/visualization/application/services/visualization-slide.service.ts
@@ -51,7 +51,7 @@ export class VisualizationSlideService {
         return this.vizSlideRepo.existsNonCompletedByJobId(jobId);
     }
 
-    async bulkInsert(jobId: string, slides: SlideInput[]): Promise<void> {
+    async bulkInsert(jobId: string, slides: SlideInput[]): Promise<VisualizationSlide[]> {
         const rows: SlideInsertRow[] = slides.map((s) => ({
             job: { id: jobId },
             slideOrder: s.slideOrder,
@@ -59,5 +59,6 @@ export class VisualizationSlideService {
             slideFilename: s.slideFilename,
         }));
         await this.vizSlideRepo.bulkInsertIgnoreConflict(rows);
+        return this.vizSlideRepo.findAllByJobId(jobId);
     }
 }

--- a/src/modules/visualization/infrastructure/repositories/visualization-slide.repository.ts
+++ b/src/modules/visualization/infrastructure/repositories/visualization-slide.repository.ts
@@ -44,14 +44,17 @@ export class VisualizationSlideRepository {
         });
     }
 
-    async bulkInsertIgnoreConflict(rows: SlideInsertRow[]): Promise<void> {
+    async deleteAllByJobId(jobId: string): Promise<void> {
+        await this.repo.delete({ job: { id: jobId } });
+    }
+
+    async bulkInsert(rows: SlideInsertRow[]): Promise<void> {
         if (rows.length === 0) return;
         await this.repo
             .createQueryBuilder()
             .insert()
             .into(VisualizationSlide)
             .values(rows as QueryDeepPartialEntity<VisualizationSlide>[])
-            .orIgnore()
             .execute();
     }
 }


### PR DESCRIPTION
<!--
PR 제목 형식: TYPE: 설명 (#이슈번호)
예시: Feat: 포트폴리오 CRUD API 구현 (#15)

TYPE: Feat, Fix, Refactor, Chore, Docs, Test, Style
-->

## Summary

POST /slide-plan 호출 시 저장된 슬라이드 목록을 반환하도록 응답을 수정합니다.

## Changes

- 응답 수정

## Type of Change

해당하는 항목에 체크해주세요:

- [ ] Bug fix (기존 기능을 수정하는 변경)
- [ ] New feature (새로운 기능 추가)
- [x] Breaking change (기존 기능에 영향을 주는 변경)
- [ ] Refactoring (기능 변경 없이 코드 개선)
- [ ] Documentation (문서 변경)
- [ ] Chore (빌드, 설정 등)

## Target Environment

배포 대상 브랜치를 선택해주세요:

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## Related Issues

관련 이슈를 연결해주세요:

- Closes #405

## Testing

테스트 방법을 작성해주세요:

- [ ] Postman/Swagger로 API 호출 확인
- [ ] 단위 테스트 통과
- [ ] E2E 테스트 통과

## Checklist

PR 생성 전 확인사항:

- [ ] 코드 컨벤션을 준수했습니다 (`docs/development/CODE_STYLE.md`)
- [ ] Git 컨벤션을 준수했습니다 (`docs/development/GIT_CONVENTIONS.md`)
- [ ] 네이밍 컨벤션을 준수했습니다 (`docs/development/NAMING_CONVENTIONS.md`)
- [x] 로컬에서 빌드가 성공합니다 (`pnpm run build`)
- [x] 로컬에서 린트가 통과합니다 (`pnpm run lint`)
- [x] (API 변경 시) Swagger 문서가 업데이트되었습니다
- [ ] (필요 시) 테스트 코드를 작성했습니다

## Screenshots (Optional)

UI 변경이 있다면 스크린샷을 첨부해주세요.

## Additional Notes

리뷰어에게 전달할 추가 정보가 있다면 작성해주세요.
