### PR TITLE
Chore: GCP 프로젝트 ID 교체 - Prod (#408)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,7 +18,7 @@
 services:
     # ── Dev Blue Slot ──
     dev-blue:
-        image: ${DOCKER_IMAGE:-asia-northeast3-docker.pkg.dev/folioo-488916/folioo-docker/folioo-server}:dev
+        image: ${DOCKER_IMAGE:-asia-northeast3-docker.pkg.dev/folioo-498017/folioo-docker/folioo-server}:dev
         restart: unless-stopped
         env_file:
             - path: .env.dev
@@ -50,7 +50,7 @@ services:
 
     # ── Dev Green Slot ──
     dev-green:
-        image: ${DOCKER_IMAGE:-asia-northeast3-docker.pkg.dev/folioo-488916/folioo-docker/folioo-server}:dev
+        image: ${DOCKER_IMAGE:-asia-northeast3-docker.pkg.dev/folioo-498017/folioo-docker/folioo-server}:dev
         restart: unless-stopped
         env_file:
             - path: .env.dev

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,7 +18,7 @@
 services:
     # ── Production Blue Slot ──
     prod-blue:
-        image: ${DOCKER_IMAGE:-asia-northeast3-docker.pkg.dev/folioo-488916/folioo-docker/folioo-server}:latest
+        image: ${DOCKER_IMAGE:-asia-northeast3-docker.pkg.dev/folioo-498017/folioo-docker/folioo-server}:latest
         restart: unless-stopped
         env_file:
             - path: .env.prod
@@ -50,7 +50,7 @@ services:
 
     # ── Production Green Slot ──
     prod-green:
-        image: ${DOCKER_IMAGE:-asia-northeast3-docker.pkg.dev/folioo-488916/folioo-docker/folioo-server}:latest
+        image: ${DOCKER_IMAGE:-asia-northeast3-docker.pkg.dev/folioo-498017/folioo-docker/folioo-server}:latest
         restart: unless-stopped
         env_file:
             - path: .env.prod


### PR DESCRIPTION
## Summary
GCP 프로젝트 이관에 따라 Docker Compose 파일 내 하드코딩된 프로젝트 ID 교체 (Prod 적용)

## Changes
- docker-compose.prod.yml의 Artifact Registry 주소 업데이트 (folioo-488916 → folioo-498017)

## Type of Change
- [x] Chore (빌드, 설정 등)

## Target Environment
- [x] Prod (`main`)

## Testing
- [x] Postman/Swagger로 API 호출 확인

## Checklist
- [x] 코드 컨벤션을 준수했습니다
- [x] Git 컨벤션을 준수했습니다

## Additional Notes
Dev 환경에서 동일한 변경이 적용되어 정상 배포 확인 완료.