### PR TITLE
Fix: 인터뷰 포트폴리오 생성 조건에 turnNumber 기준 추가

### DIFF
--- a/src/common/exceptions/error-code.ts
+++ b/src/common/exceptions/error-code.ts
@@ -166,7 +166,7 @@ export const ErrorMap: Record<ErrorCode, ErrorDetail> = {
     },
     [ErrorCode.INTERVIEW_NOT_COMPLETED]: {
         message:
-            '인터뷰가 아직 완료되지 않았습니다. 모든 질문에 답변한 후 포트폴리오를 생성할 수 있습니다.',
+            '인터뷰가 아직 완료되지 않았습니다. 모든 질문에 답변하거나 18턴 이상 진행한 후 포트폴리오를 생성할 수 있습니다.',
         statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
     },
     [ErrorCode.INTERVIEW_EXTEND_NOT_ALLOWED]: {

--- a/src/modules/interview/application/facades/interview.facade.spec.ts
+++ b/src/modules/interview/application/facades/interview.facade.spec.ts
@@ -1,4 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+jest.mock('typeorm-transactional', () => ({
+    Transactional: () => (_target: object, _key: string, descriptor: PropertyDescriptor) =>
+        descriptor,
+    initializeTransactionalContext: jest.fn(),
+}));
+
+import { ExperienceStatus } from 'src/modules/experience/domain/enums/experience-status.enum';
+import { PortfolioStatus } from 'src/modules/portfolio/domain/enums/portfolio-status.enum';
 import { ExperienceService } from 'src/modules/experience/application/services/experience.service';
 import { InsightService } from 'src/modules/insight/application/services/insight.service';
 import { AiRelayConnection } from 'src/common/ports/ai-relay.port';
@@ -22,38 +30,52 @@ class InterviewServiceStub {
     readonly getSessionState = jest.fn<Promise<InterviewSessionStateResDTO>, [string]>();
 
     readonly extendSessionStream = jest.fn<Promise<AiRelayConnection>, [string]>();
+
+    readonly validateReadyForGeneration = jest.fn<Promise<void>, [string]>();
+
+    readonly delegatePortfolioGeneration = jest.fn<Promise<void>, [number, string, string]>();
 }
 
 class ExperienceServiceStub {
     readonly findByIdOrThrow = jest.fn<
-        Promise<{ id: number; name: string; sessionId?: string | null }>,
+        Promise<{ id: number; name: string; sessionId?: string | null; status?: ExperienceStatus }>,
         [number, number]
     >();
     readonly saveInterviewSessionId = jest.fn<Promise<void>, [number, number, string]>();
+    readonly transitionToGenerate = jest.fn<
+        Promise<{ id: number; name: string; sessionId: string | null; status: ExperienceStatus }>,
+        [unknown]
+    >();
+    readonly transitionToGenerateFailed = jest.fn<Promise<void>, [number]>();
 }
 
 class InsightServiceStub {
     readonly findByIdAndUserOrThrow = jest.fn<Promise<{ id: number }>, [number, number]>();
 }
 
-class PortfolioServiceStub {}
+class PortfolioServiceStub {
+    readonly savePortfolio = jest.fn<Promise<{ id: number; status: PortfolioStatus }>, [unknown]>();
+    readonly removeGeneratingPortfolio = jest.fn<Promise<void>, [number]>();
+}
 
 describe('InterviewFacade', () => {
     let interviewFacade: InterviewFacade;
     let interviewServiceStub: InterviewServiceStub;
     let experienceServiceStub: ExperienceServiceStub;
     let insightServiceStub: InsightServiceStub;
+    let portfolioServiceStub: PortfolioServiceStub;
 
     beforeEach(() => {
         interviewServiceStub = new InterviewServiceStub();
         experienceServiceStub = new ExperienceServiceStub();
         insightServiceStub = new InsightServiceStub();
+        portfolioServiceStub = new PortfolioServiceStub();
 
         interviewFacade = new InterviewFacade(
             interviewServiceStub as unknown as InterviewService,
             experienceServiceStub as unknown as ExperienceService,
             insightServiceStub as unknown as InsightService,
-            new PortfolioServiceStub() as unknown as PortfolioService
+            portfolioServiceStub as unknown as PortfolioService
         );
     });
 
@@ -308,6 +330,56 @@ describe('InterviewFacade', () => {
         );
         expect(interviewServiceStub.getSessionState).not.toHaveBeenCalled();
         expect(interviewServiceStub.extendSessionStream).not.toHaveBeenCalled();
+    });
+
+    describe('generatePortfolio', () => {
+        it('proceeds with generation when allComplete is false but turnNumber is 18', async () => {
+            const experience = {
+                id: 30,
+                name: '테스트 경험',
+                sessionId: 'session_generate_ok',
+                status: ExperienceStatus.ON_CHAT,
+            };
+            experienceServiceStub.findByIdOrThrow.mockResolvedValue(experience);
+            interviewServiceStub.validateReadyForGeneration.mockResolvedValue();
+            experienceServiceStub.transitionToGenerate.mockResolvedValue({
+                ...experience,
+                status: ExperienceStatus.GENERATE,
+            });
+            portfolioServiceStub.savePortfolio.mockResolvedValue({
+                id: 99,
+                status: PortfolioStatus.GENERATING,
+            });
+            interviewServiceStub.delegatePortfolioGeneration.mockResolvedValue();
+
+            const result = await interviewFacade.generatePortfolio(30, 42);
+
+            expect(interviewServiceStub.validateReadyForGeneration).toHaveBeenCalledWith(
+                'session_generate_ok'
+            );
+            expect(result.portfolioId).toBe(99);
+        });
+
+        it('throws INTERVIEW_NOT_COMPLETED when allComplete is false and turnNumber is 17', async () => {
+            const experience = {
+                id: 31,
+                name: '테스트 경험',
+                sessionId: 'session_not_ready',
+            };
+            experienceServiceStub.findByIdOrThrow.mockResolvedValue(experience);
+            interviewServiceStub.validateReadyForGeneration.mockRejectedValue(
+                new BusinessException(ErrorCode.INTERVIEW_NOT_COMPLETED)
+            );
+
+            await expect(interviewFacade.generatePortfolio(31, 42)).rejects.toMatchObject(
+                expect.objectContaining({
+                    response: expect.objectContaining({
+                        errorCode: ErrorCode.INTERVIEW_NOT_COMPLETED,
+                    }),
+                })
+            );
+            expect(portfolioServiceStub.savePortfolio).not.toHaveBeenCalled();
+        });
     });
 
     it('throws INTERVIEW_EXTEND_NOT_ALLOWED when interview is not completed', async () => {

--- a/src/modules/interview/application/facades/interview.facade.ts
+++ b/src/modules/interview/application/facades/interview.facade.ts
@@ -126,10 +126,7 @@ export class InterviewFacade {
             throw new BusinessException(ErrorCode.EXPERIENCE_SESSION_NOT_READY, { experienceId });
         }
 
-        const sessionState = await this.interviewService.getSessionState(experience.sessionId);
-        if (!sessionState.allComplete && sessionState.turnNumber < 18) {
-            throw new BusinessException(ErrorCode.INTERVIEW_NOT_COMPLETED);
-        }
+        await this.interviewService.validateReadyForGeneration(experience.sessionId);
 
         const result = await this.executePortfolioGeneration(experience, userId);
 

--- a/src/modules/interview/application/facades/interview.facade.ts
+++ b/src/modules/interview/application/facades/interview.facade.ts
@@ -127,7 +127,7 @@ export class InterviewFacade {
         }
 
         const sessionState = await this.interviewService.getSessionState(experience.sessionId);
-        if (!sessionState.allComplete) {
+        if (!sessionState.allComplete && sessionState.turnNumber < 18) {
             throw new BusinessException(ErrorCode.INTERVIEW_NOT_COMPLETED);
         }
 

--- a/src/modules/interview/application/services/interview.service.spec.ts
+++ b/src/modules/interview/application/services/interview.service.spec.ts
@@ -6,6 +6,7 @@ import {
     AiRelayPort,
     AiRelayRequest,
 } from 'src/common/ports/ai-relay.port';
+import { ErrorCode } from 'src/common/exceptions/error-code.enum';
 import { InterviewSessionStateResDTO } from '../dtos/interview.dto';
 import { InterviewService } from './interview.service';
 
@@ -206,6 +207,62 @@ describe('InterviewService', () => {
         expect(aiRelayPortStub.openPostStreamMock).toHaveBeenCalledWith({
             path: '/api/v1/interview/sessions/session%201%2F2/extend/stream',
             body: {},
+        });
+    });
+
+    describe('validateReadyForGeneration', () => {
+        function makeStatePayload(allComplete: boolean, turnNumber: number) {
+            return {
+                messages: [],
+                experience_name: '경험',
+                current_stage: 1,
+                all_complete: allComplete,
+                turn_number: turnNumber,
+                insight_turn_history: [],
+            };
+        }
+
+        it('resolves when allComplete is false and turnNumber is 18', async () => {
+            aiRelayPortStub.getJsonMock.mockResolvedValue({
+                data: makeStatePayload(false, 18),
+                status: 200,
+                headers: {},
+            });
+
+            await expect(
+                interviewService.validateReadyForGeneration('session_abc')
+            ).resolves.toBeUndefined();
+        });
+
+        it('throws INTERVIEW_NOT_COMPLETED when allComplete is false and turnNumber is 17', async () => {
+            aiRelayPortStub.getJsonMock.mockResolvedValue({
+                data: makeStatePayload(false, 17),
+                status: 200,
+                headers: {},
+            });
+
+            await expect(
+                interviewService.validateReadyForGeneration('session_abc')
+            ).rejects.toMatchObject(
+                expect.objectContaining({
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    response: expect.objectContaining({
+                        errorCode: ErrorCode.INTERVIEW_NOT_COMPLETED,
+                    }),
+                })
+            );
+        });
+
+        it('resolves when allComplete is true regardless of turnNumber', async () => {
+            aiRelayPortStub.getJsonMock.mockResolvedValue({
+                data: makeStatePayload(true, 5),
+                status: 200,
+                headers: {},
+            });
+
+            await expect(
+                interviewService.validateReadyForGeneration('session_abc')
+            ).resolves.toBeUndefined();
         });
     });
 });

--- a/src/modules/interview/application/services/interview.service.ts
+++ b/src/modules/interview/application/services/interview.service.ts
@@ -1,4 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
+import { BusinessException } from 'src/common/exceptions/business.exception';
+import { ErrorCode } from 'src/common/exceptions/error-code.enum';
 import { AiRelayConnection, AiRelayPort } from 'src/common/ports/ai-relay.port';
 import { InterviewChatUploadFile } from '../../presentation/services/interview-chat-stream-request-parser.service';
 import {
@@ -8,6 +10,8 @@ import {
 
 const CREATE_SESSION_STREAM_PATH = '/api/v1/interview/sessions/stream';
 const SESSION_BASE_PATH = '/api/v1/interview/sessions';
+
+export const MIN_PORTFOLIO_TURN = 18;
 
 const sessionPath = (sessionId: string, suffix: string): string =>
     `${SESSION_BASE_PATH}/${encodeURIComponent(sessionId)}${suffix}`;
@@ -69,6 +73,13 @@ export class InterviewService {
         });
 
         return InterviewSessionStateResDTO.fromAiPayload(response.data);
+    }
+
+    async validateReadyForGeneration(sessionId: string): Promise<void> {
+        const sessionState = await this.getSessionState(sessionId);
+        if (!sessionState.allComplete && sessionState.turnNumber < MIN_PORTFOLIO_TURN) {
+            throw new BusinessException(ErrorCode.INTERVIEW_NOT_COMPLETED);
+        }
     }
 
     async delegatePortfolioGeneration(


### PR DESCRIPTION
## Summary

  포트폴리오 생성 시 `allComplete`가 false여도 `turnNumber >= 18`이면
  생성이 가능하도록 조건을 완화합니다.

  ## Changes

  - `InterviewFacade.generatePortfolio`의 완료 조건 수정
    - 기존: `allComplete`가 true일 때만 생성 허용
    - 변경: `allComplete || turnNumber >= 18`이면 생성 허용

  ## Type of Change

  - [x] Bug fix (기존 기능을 수정하는 변경)
  
  ## Target Environment

  - [x] Dev (`dev`)

  ## Related Issues

  - Closes #416 

  ## Testing

  - [ ] Postman/Swagger로 API 호출 확인
    - `turnNumber >= 18` && `allComplete: false` 상태에서 생성 요청 시 정상 진행 확인
    - `turnNumber < 18` && `allComplete: false` 상태에서 `INTERVIEW_NOT_COMPLETED` 에러 반환 확인

  ## Checklist

  - [x] 코드 컨벤션을 준수했습니다
  - [x] Git 컨벤션을 준수했습니다
  - [x] 네이밍 컨벤션을 준수했습니다
  - [x] 로컬에서 빌드가 성공합니다
  - [x] 로컬에서 린트가 통과합니다

  ## Screenshots (Optional)

  N/A

  ## Additional Notes

  `turnNumber`는 AI 서버의 `/state` 응답에서 내려오는 값입니다.
  `allComplete`가 영구적으로 false로 내려오는 경우에도 일정 턴 이상
  진행했다면 생성으로 넘어갈 수 있도록 fallback 조건을 추가했습니다.