### PR TITLE
Feat: 블록 템플릿 카탈로그 및 기본 시딩 구현

### DIFF
--- a/src/modules/block/application/dtos/template.dto.ts
+++ b/src/modules/block/application/dtos/template.dto.ts
@@ -1,0 +1,71 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SectionKind } from '../../domain/enums/section-kind.enum';
+import { CategorySlot, SubTemplate } from '../../domain/templates/template-catalog';
+
+export class TemplateSlotResDTO {
+    @ApiProperty({ example: 'DETAIL.MOTIVATION' })
+    slotId: string;
+
+    @ApiProperty({
+        example: '어떤 계기로 이 활동을 시작했으며, 최종적으로 달성하고자 한 목표는 무엇인가요?',
+    })
+    placeholder: string;
+
+    @ApiProperty({ example: '교내 커뮤니티의 비효율적인 게시판형 거래 방식을 개선하고...' })
+    example: string;
+
+    static fromCategorySlot(slot: CategorySlot): TemplateSlotResDTO {
+        const dto = new TemplateSlotResDTO();
+        dto.slotId = slot.slotId;
+        dto.placeholder = slot.placeholder;
+        dto.example = slot.example;
+        return dto;
+    }
+}
+
+export class TemplateSubTemplateResDTO {
+    @ApiProperty({ example: 'BASIC' })
+    templateId: string;
+
+    @ApiProperty({ example: '기본' })
+    label: string;
+
+    @ApiProperty({ type: () => [TemplateSlotResDTO] })
+    slots: TemplateSlotResDTO[];
+
+    static from(subTemplate: SubTemplate): TemplateSubTemplateResDTO {
+        const dto = new TemplateSubTemplateResDTO();
+        dto.templateId = subTemplate.templateId;
+        dto.label = subTemplate.label;
+        dto.slots = subTemplate.slots.map((slot) => {
+            const slotDto = new TemplateSlotResDTO();
+            slotDto.slotId = slot.slotId;
+            slotDto.placeholder = slot.placeholder;
+            slotDto.example = slot.example;
+            return slotDto;
+        });
+        return dto;
+    }
+}
+
+export class TemplateSectionResDTO {
+    @ApiProperty({ enum: SectionKind })
+    sectionKind: SectionKind;
+
+    @ApiProperty({ required: false, nullable: true, example: 'TASK.SUMMARY' })
+    anchorSlotId: string | null;
+
+    @ApiProperty({ type: () => [TemplateSlotResDTO], description: 'level 4 카테고리 슬롯' })
+    slots: TemplateSlotResDTO[];
+
+    @ApiProperty({
+        type: () => [TemplateSubTemplateResDTO],
+        description: 'level 5 하위 템플릿 (없으면 빈 배열)',
+    })
+    subTemplates: TemplateSubTemplateResDTO[];
+}
+
+export class TemplateCatalogResDTO {
+    @ApiProperty({ type: () => [TemplateSectionResDTO] })
+    sections: TemplateSectionResDTO[];
+}

--- a/src/modules/block/application/services/block.service.ts
+++ b/src/modules/block/application/services/block.service.ts
@@ -13,6 +13,12 @@ import {
 import { BlockKindEntity } from '../../domain/block-kind.entity';
 import { ExperienceMeta } from '../../domain/experience-meta.entity';
 import { BlockKind, EXPERIENCE_SECTION_KINDS } from '../../domain/enums/block-kind.enum';
+import { BLOCK_KIND_TO_SECTION_KIND, SectionKind } from '../../domain/enums/section-kind.enum';
+import {
+    getAnchorSlot,
+    getCategorySlotsForSection,
+    getDefaultSubTemplate,
+} from '../../domain/templates/template-catalog';
 
 const NAME_LEVEL_KINDS: readonly BlockKind[] = [BlockKind.GROUP, BlockKind.EXPERIENCE];
 
@@ -80,7 +86,7 @@ export class BlockService {
         block.kind = kind;
         block.position = await this.blockRepository.countChildren(userId, parentId);
         block.content = content;
-        block.placeholder = null;
+        block.placeholder = this.resolveDefaultPlaceholder(kind, parent);
         const savedBlock = await this.blockRepository.save(block);
 
         if (kind === BlockKind.EXPERIENCE) {
@@ -243,12 +249,78 @@ export class BlockService {
             section.placeholder = null;
             return section;
         });
-        await this.blockRepository.saveAll(sections);
+        const savedSections = await this.blockRepository.saveAll(sections);
 
         const experienceMeta = new ExperienceMeta();
         experienceMeta.blockId = experienceBlock.id;
         experienceMeta.blockKind = BlockKind.EXPERIENCE;
         await this.experienceMetaRepository.save(experienceMeta);
+
+        await this.provisionDefaultContentSlots(savedSections);
+    }
+
+    // 문서 "1. 기본 제공 데이터" — 섹션별 level4 카테고리 슬롯 10개 + TASK/PROBLEM_SOLVING
+    // 앵커 하위 기본(BASIC) 템플릿 level5 슬롯 8개, 총 18개를 빈 content + 지정 placeholder로 생성한다.
+    private async provisionDefaultContentSlots(sections: Block[]): Promise<void> {
+        const level4Blocks: Block[] = [];
+        const anchorBlockBySection = new Map<SectionKind, Block>();
+
+        for (const section of sections) {
+            const sectionKind = BLOCK_KIND_TO_SECTION_KIND.get(section.kind);
+            if (!sectionKind) continue;
+
+            getCategorySlotsForSection(sectionKind).forEach((slot, index) => {
+                const block = new Block();
+                block.userId = section.userId;
+                block.parent = section;
+                block.parentId = section.id;
+                block.level = section.level + 1;
+                block.kind = BlockKind.CONTENT;
+                block.position = index;
+                block.content = null;
+                block.placeholder = slot.placeholder;
+                level4Blocks.push(block);
+                if (slot.isAnchor) {
+                    anchorBlockBySection.set(sectionKind, block);
+                }
+            });
+        }
+        await this.blockRepository.saveAll(level4Blocks);
+
+        const level5Blocks: Block[] = [];
+        for (const [sectionKind, anchorBlock] of anchorBlockBySection) {
+            const defaultTemplate = getDefaultSubTemplate(sectionKind);
+            if (!defaultTemplate) continue;
+
+            defaultTemplate.slots.forEach((slot, index) => {
+                const block = new Block();
+                block.userId = anchorBlock.userId;
+                block.parent = anchorBlock;
+                block.parentId = anchorBlock.id;
+                block.level = anchorBlock.level + 1;
+                block.kind = BlockKind.CONTENT;
+                block.position = index;
+                block.content = null;
+                block.placeholder = slot.placeholder;
+                level5Blocks.push(block);
+            });
+        }
+        if (level5Blocks.length > 0) {
+            await this.blockRepository.saveAll(level5Blocks);
+        }
+    }
+
+    // 문서 "0. 기본 placeholder" — 담당업무/문제해결 섹션 아래 새로 생성되는 4단계 블록은
+    // 앵커 슬롯의 placeholder를 그대로 쓰고, 그 외에는 block_kind의 기본 placeholder로 폴백한다.
+    private resolveDefaultPlaceholder(kind: BlockKind, parent: Block | null): string | null {
+        if (kind !== BlockKind.CONTENT || !parent) {
+            return null;
+        }
+        const sectionKind = BLOCK_KIND_TO_SECTION_KIND.get(parent.kind);
+        if (!sectionKind) {
+            return null;
+        }
+        return getAnchorSlot(sectionKind)?.placeholder ?? null;
     }
 
     private assertValidPlacement(kind: BlockKind, parent: Block | null): void {

--- a/src/modules/block/application/services/template-catalog.service.ts
+++ b/src/modules/block/application/services/template-catalog.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { SectionKind } from '../../domain/enums/section-kind.enum';
+import {
+    getAnchorSlot,
+    getCategorySlotsForSection,
+    getSubTemplatesForSection,
+} from '../../domain/templates/template-catalog';
+import {
+    TemplateCatalogResDTO,
+    TemplateSectionResDTO,
+    TemplateSlotResDTO,
+    TemplateSubTemplateResDTO,
+} from '../dtos/template.dto';
+
+@Injectable()
+export class TemplateCatalogService {
+    getCatalog(): TemplateCatalogResDTO {
+        const catalog = new TemplateCatalogResDTO();
+        catalog.sections = Object.values(SectionKind).map((sectionKind) =>
+            this.buildSection(sectionKind)
+        );
+        return catalog;
+    }
+
+    private buildSection(sectionKind: SectionKind): TemplateSectionResDTO {
+        const section = new TemplateSectionResDTO();
+        section.sectionKind = sectionKind;
+        section.anchorSlotId = getAnchorSlot(sectionKind)?.slotId ?? null;
+        section.slots = getCategorySlotsForSection(sectionKind).map((slot) =>
+            TemplateSlotResDTO.fromCategorySlot(slot)
+        );
+        section.subTemplates = getSubTemplatesForSection(sectionKind).map((subTemplate) =>
+            TemplateSubTemplateResDTO.from(subTemplate)
+        );
+        return section;
+    }
+}

--- a/src/modules/block/block.module.ts
+++ b/src/modules/block/block.module.ts
@@ -17,6 +17,8 @@ import { ExperienceMapService } from './application/services/experience-map.serv
 import { ExperienceMetaService } from './application/services/experience-meta.service';
 import { ExperienceMapFacade } from './application/facades/experience-map.facade';
 import { ExperienceMapController } from './presentation/experience-map.controller';
+import { TemplateCatalogService } from './application/services/template-catalog.service';
+import { TemplateController } from './presentation/template.controller';
 
 @Module({
     imports: [
@@ -31,7 +33,7 @@ import { ExperienceMapController } from './presentation/experience-map.controlle
             AiCommitLog,
         ]),
     ],
-    controllers: [ExperienceMapController],
+    controllers: [ExperienceMapController, TemplateController],
     providers: [
         BlockRepository,
         BlockKindRepository,
@@ -41,6 +43,7 @@ import { ExperienceMapController } from './presentation/experience-map.controlle
         ExperienceMapService,
         ExperienceMetaService,
         ExperienceMapFacade,
+        TemplateCatalogService,
     ],
 })
 export class BlockModule {}

--- a/src/modules/block/domain/enums/section-kind.enum.ts
+++ b/src/modules/block/domain/enums/section-kind.enum.ts
@@ -1,0 +1,26 @@
+import { BlockKind } from './block-kind.enum';
+
+// block_kind_enum(DB)과 별개로 유지하는 API/AI 계약용 식별자.
+// DB enum이 바뀌어도 slot_id 등 외부 계약이 깨지지 않도록 분리한다.
+export enum SectionKind {
+    DETAIL = 'DETAIL',
+    ACHIEVEMENT = 'ACHIEVEMENT',
+    TASK = 'TASK',
+    PROBLEM_SOLVING = 'PROBLEM_SOLVING',
+    LEARNING = 'LEARNING',
+}
+
+export const SECTION_KIND_TO_BLOCK_KIND: Readonly<Record<SectionKind, BlockKind>> = {
+    [SectionKind.DETAIL]: BlockKind.SECTION_DETAIL,
+    [SectionKind.ACHIEVEMENT]: BlockKind.SECTION_ACHIEVEMENT,
+    [SectionKind.TASK]: BlockKind.SECTION_TASK,
+    [SectionKind.PROBLEM_SOLVING]: BlockKind.SECTION_PROBLEM_SOLVING,
+    [SectionKind.LEARNING]: BlockKind.SECTION_LEARNING,
+};
+
+export const BLOCK_KIND_TO_SECTION_KIND: ReadonlyMap<BlockKind, SectionKind> = new Map(
+    Object.entries(SECTION_KIND_TO_BLOCK_KIND).map(([sectionKind, blockKind]) => [
+        blockKind,
+        sectionKind as SectionKind,
+    ])
+);

--- a/src/modules/block/domain/templates/template-catalog.ts
+++ b/src/modules/block/domain/templates/template-catalog.ts
@@ -1,0 +1,399 @@
+import { SectionKind } from '../enums/section-kind.enum';
+
+export interface CategorySlot {
+    slotId: string;
+    sectionKind: SectionKind;
+    slot: string;
+    placeholder: string;
+    example: string;
+    isAnchor: boolean;
+}
+
+export interface SubTemplateSlot {
+    slotId: string;
+    slot: string;
+    placeholder: string;
+    example: string;
+}
+
+export interface SubTemplate {
+    sectionKind: SectionKind;
+    templateId: string;
+    label: string;
+    slots: SubTemplateSlot[];
+}
+
+// level 4 카테고리 슬롯 (10개). 순서 = 화면/생성 순서.
+export const CATEGORY_SLOTS: readonly CategorySlot[] = [
+    {
+        slotId: 'DETAIL.MOTIVATION',
+        sectionKind: SectionKind.DETAIL,
+        slot: 'MOTIVATION',
+        placeholder:
+            '어떤 계기로 이 활동을 시작했으며, 최종적으로 달성하고자 한 목표는 무엇인가요?',
+        example:
+            '교내 커뮤니티의 비효율적인 게시판형 거래 방식을 개선하고, 전공 서적 거래의 편의성과 신뢰도를 높이기 위한 전용 플랫폼 기획 및 앱 리뉴얼',
+        isAnchor: false,
+    },
+    {
+        slotId: 'DETAIL.PERIOD',
+        sectionKind: SectionKind.DETAIL,
+        slot: 'PERIOD',
+        placeholder: '전체 진행 기간은 언제부터 언제까지였나요?',
+        example: '2023.09 ~ 2023.12 (4개월)',
+        isAnchor: false,
+    },
+    {
+        slotId: 'DETAIL.ROLE',
+        sectionKind: SectionKind.DETAIL,
+        slot: 'ROLE',
+        placeholder: '본인의 역할은 무엇이었으며, 전체 인원과 역할 분담은 어떻게 구성되었나요?',
+        example: '기획 1명 (본인), 디자인 1명, 개발 2명 (총 4인 팀)',
+        isAnchor: false,
+    },
+    {
+        slotId: 'DETAIL.TARGET',
+        sectionKind: SectionKind.DETAIL,
+        slot: 'TARGET',
+        placeholder: '주요 타깃, 사용자, 혹은 고객은 누구였나요?',
+        example:
+            '비싼 전공 서적 가격에 부담을 느끼며, 교내 직거래를 통해 택배비 절약과 빠른 거래를 원하는 대학생',
+        isAnchor: false,
+    },
+    {
+        slotId: 'DETAIL.STACK',
+        sectionKind: SectionKind.DETAIL,
+        slot: 'STACK',
+        placeholder: '진행 과정에서 본인이 직접 활용한 기술, 방법론, 혹은 툴은 무엇인가요?',
+        example: 'Figma, Notion, Slack, Google Analytics, IDI(심층 인터뷰), Usability Test',
+        isAnchor: false,
+    },
+    {
+        slotId: 'ACHIEVEMENT.QUANTITATIVE',
+        sectionKind: SectionKind.ACHIEVEMENT,
+        slot: 'QUANTITATIVE',
+        placeholder: '수치로 증명할 수 있는 정량적인 성과는 무엇인가요?',
+        example: '리뉴얼 전 대비 DAU(일간 활성 사용자) 150% 증가',
+        isAnchor: false,
+    },
+    {
+        slotId: 'ACHIEVEMENT.QUALITATIVE',
+        sectionKind: SectionKind.ACHIEVEMENT,
+        slot: 'QUALITATIVE',
+        placeholder: '간접적인 지표로 확인할 수 있는 정성적인 성과는 무엇인가요?',
+        example: '"검색부터 구매 약속까지 과정이 직관적이다"라는 사용자 피드백 다수 확보',
+        isAnchor: false,
+    },
+    {
+        slotId: 'TASK.SUMMARY',
+        sectionKind: SectionKind.TASK,
+        slot: 'SUMMARY',
+        placeholder: '담당한 주요 업무 또는 역할을 적어주세요.',
+        example: '사용자 리서치 및 문제 정의',
+        isAnchor: true,
+    },
+    {
+        slotId: 'PROBLEM_SOLVING.SUMMARY',
+        sectionKind: SectionKind.PROBLEM_SOLVING,
+        slot: 'SUMMARY',
+        placeholder: '문제해결 에피소드를 한 줄로 요약해 주세요.',
+        example: '신규 프로모션 페이지 가입 이탈 문제 해결',
+        isAnchor: true,
+    },
+    {
+        slotId: 'LEARNING.GROWTH',
+        sectionKind: SectionKind.LEARNING,
+        slot: 'GROWTH',
+        placeholder:
+            '이 활동을 통해 새롭게 배우거나 성장한 점은 무엇이며, 향후 어떻게 활용할 계획인가요?',
+        example:
+            '이번 프로젝트에서는 구글 애널리틱스를 기초적으로만 활용했지만, 향후에는 SQL을 학습하여 직접 DB에서 데이터를 추출하고 더 정교하게 사용자 행동 데이터를 분석해 보고 싶다.',
+        isAnchor: false,
+    },
+];
+
+// level 5 하위 템플릿 (7종 x 4슬롯 = 28개). TASK/PROBLEM_SOLVING 앵커 아래에만 붙는다.
+export const SUB_TEMPLATES: readonly SubTemplate[] = [
+    {
+        sectionKind: SectionKind.TASK,
+        templateId: 'BASIC',
+        label: '기본',
+        slots: [
+            {
+                slotId: 'TASK.BASIC.PURPOSE',
+                slot: 'PURPOSE',
+                placeholder:
+                    '이 업무를 진행한 목적은 무엇이며, 구체적으로 어떤 목표를 달성하고자 했나요?',
+                example:
+                    '신규 브랜드 인지도를 확대하고, 2030 타겟 고객의 공식 SNS 채널 팔로워 1만 명 확보를 목표로 설정',
+            },
+            {
+                slotId: 'TASK.BASIC.RESEARCH',
+                slot: 'RESEARCH',
+                placeholder:
+                    '원활한 업무 수행을 위해 조사한 정보나 추가로 학습한 내용은 무엇인가요?',
+                example:
+                    '최근 소셜 미디어 알고리즘 변화와 타겟층이 선호하는 숏폼 영상 트렌드, 타사의 바이럴 성공 사례를 집중적으로 조사',
+            },
+            {
+                slotId: 'TASK.BASIC.EXECUTION',
+                slot: 'EXECUTION',
+                placeholder: '실제 작업은 어떤 방식으로, 어떤 과정을 거쳐서 진행했나요?',
+                example:
+                    '브랜드 핵심 메시지를 15초 이내로 압축한 숏폼 시리즈를 제작하고, A/B 테스트를 통해 반응률이 높은 소재에 광고 예산을 집중하는 방식으로 운영',
+            },
+            {
+                slotId: 'TASK.BASIC.RESULT',
+                slot: 'RESULT',
+                placeholder:
+                    '업무 완료 후 나타난 결과는 무엇이며, 이 과정을 통해 배운 점은 무엇인가요?',
+                example:
+                    '캠페인 한 달 만에 목표 팔로워 1만 명을 조기 달성했으며, 영상 도입부 3초의 시각적 요소가 사용자 체류 시간과 전환에 미치는 결정적인 영향을 체득',
+            },
+        ],
+    },
+    {
+        sectionKind: SectionKind.PROBLEM_SOLVING,
+        templateId: 'BASIC',
+        label: '기본',
+        slots: [
+            {
+                slotId: 'PROBLEM_SOLVING.BASIC.PROBLEM',
+                slot: 'PROBLEM',
+                placeholder: '어떤 문제가 발생했으며, 이를 해결해야 했던 이유는 무엇인가요?',
+                example:
+                    '신규 프로모션 페이지 이탈률 70% 초과, 목표 가입자 수 달성을 위해 전환율 개선 필요',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.BASIC.CAUSE',
+                slot: 'CAUSE',
+                placeholder: '문제의 원인은 무엇이었고, 어떤 방식으로 원인을 파악했나요?',
+                example:
+                    'GA4 퍼널 분석으로 사용자 이탈 구간을 추적하여, 모호한 CTA 카피와 복잡한 혜택 설명이 가입 단계의 병목 원인임을 확인',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.BASIC.SOLUTION',
+                slot: 'SOLUTION',
+                placeholder: '해결책을 도출한 과정과 구체적인 실행 방법은 무엇인가요?',
+                example:
+                    '핵심 혜택을 직관적으로 강조한 3가지 카피로 A/B 테스트 기획 후 일정 기간 노출하여 클릭률 변화를 추적',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.BASIC.RESULT',
+                slot: 'RESULT',
+                placeholder:
+                    '해결책 적용 후 나타난 결과와 그 검증 방법, 그리고 이 과정을 통해 배운 점은 무엇인가요?',
+                example:
+                    '개선안 적용 후 가입 전환율 15% 상승, 타깃 니즈에 맞춘 직관적인 메시징과 데이터 기반 가설 검증의 중요성을 체득',
+            },
+        ],
+    },
+    {
+        sectionKind: SectionKind.PROBLEM_SOLVING,
+        templateId: 'INTERPERSONAL',
+        label: '대인관계',
+        slots: [
+            {
+                slotId: 'PROBLEM_SOLVING.INTERPERSONAL.SITUATION',
+                slot: 'SITUATION',
+                placeholder: '누구와 어떤 상황에서 의견 차이나 문제가 발생했나요?',
+                example:
+                    '자료 조사 범위와 회의 진행 방식을 두고 팀원들 간의 의견 대립 및 참여도 저하 발생',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.INTERPERSONAL.ACTION',
+                slot: 'ACTION',
+                placeholder: '문제를 해결하기 위해 상대방과 어떻게 소통하고 어떤 행동을 취했나요?',
+                example:
+                    '팀원들과 개별 면담을 통해 각자의 불만 사항과 상황을 청취. 이후 회의 시간 제한, 역할 재분배 등 모두가 동의할 수 있는 명확한 규칙 수립 및 제안',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.INTERPERSONAL.OUTCOME',
+                slot: 'OUTCOME',
+                placeholder:
+                    '본인의 대응으로 인해 상대방의 반응이나 상황은 어떻게 변화하고 마무리되었나요?',
+                example:
+                    '새로운 규칙 도입 후 팀원들이 불만을 해소하고 적극적으로 아이디어를 제시하기 시작했으며, 갈등 없이 기한 내에 최종 기획서 제출 완료',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.INTERPERSONAL.LEARNING',
+                slot: 'LEARNING',
+                placeholder:
+                    '이 과정을 통해 배운 점은 무엇이며, 향후 유사한 상황에 어떻게 적용할 계획인가요?',
+                example:
+                    '상호 존중을 바탕으로 한 개별 소통과 명확한 규칙 수립이 팀워크에 미치는 긍정적인 영향을 배움. 향후 협업 시 초기 단계부터 명확한 역할 분담과 규칙을 세팅할 계획',
+            },
+        ],
+    },
+    {
+        sectionKind: SectionKind.PROBLEM_SOLVING,
+        templateId: 'PERFORMANCE',
+        label: '성과 부진 개선',
+        slots: [
+            {
+                slotId: 'PROBLEM_SOLVING.PERFORMANCE.METRIC',
+                slot: 'METRIC',
+                placeholder:
+                    '문제가 된 성과 지표는 무엇이며, 목표치와 실제 상태의 차이는 어느 정도였나요?',
+                example: '뉴스레터 오픈율 목표치는 25%이지만, 12%에 머물러 있어 개선이 시급한 상황',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.PERFORMANCE.CAUSE',
+                slot: 'CAUSE',
+                placeholder: '목표에 도달하지 못한 근본적인 원인을 무엇으로 분석했나요?',
+                example:
+                    '기존 구독자 데이터 분석 결과, 발송 시간대가 타깃의 주 활동 시간과 맞지 않고 제목이 길어 클릭을 유도하지 못함을 확인',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.PERFORMANCE.ACTION',
+                slot: 'ACTION',
+                placeholder: '개선을 위해 기존 방식을 어떻게 변경하고 어떤 새로운 시도를 했나요?',
+                example:
+                    '발송 시간을 출근 시간대로 변경하고, 제목을 15자 이내로 단축하여 핵심 키워드를 전면에 배치',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.PERFORMANCE.RESULT',
+                slot: 'RESULT',
+                placeholder: '실행 후 지표는 어떻게 달라졌으며, 개선 효과를 어떻게 검증했나요?',
+                example:
+                    '변경 후 오픈율 28%로 상승. A/B 테스트를 통해 제목 길이와 발송 시간의 상관관계를 교차 검증하여 효과 입증',
+            },
+        ],
+    },
+    {
+        sectionKind: SectionKind.PROBLEM_SOLVING,
+        templateId: 'TROUBLESHOOTING',
+        label: '기술 트러블슈팅',
+        slots: [
+            {
+                slotId: 'PROBLEM_SOLVING.TROUBLESHOOTING.PROBLEM',
+                slot: 'PROBLEM',
+                placeholder:
+                    '어떤 문제가 발생했으며, 그 문제가 미친 구체적인 영향 범위는 어디까지였나요?',
+                example:
+                    '대규모 트래픽 발생 시 결제 페이지 로딩 속도가 5초 이상 지연되어 사용자의 결제 이탈 발생',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.TROUBLESHOOTING.CAUSE',
+                slot: 'CAUSE',
+                placeholder:
+                    '문제의 원인은 무엇이었으며, 이를 파악하기 위해 어떤 검증 과정을 거쳤나요?',
+                example:
+                    'APM 툴을 활용해 병목 구간을 모니터링한 결과, 불필요한 데이터베이스 쿼리의 중복 호출이 원인임을 확인',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.TROUBLESHOOTING.SOLUTION',
+                slot: 'SOLUTION',
+                placeholder:
+                    '어떤 해결책을 선택하여 적용했으며, 여러 방법 중 그 방법을 채택한 이유는 무엇인가요?',
+                example:
+                    '쿼리 최적화 및 캐싱(Redis) 도입 선택. 서버 증설보다 비용 효율적이고 근본적인 성능 개선이 가능하기 때문',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.TROUBLESHOOTING.VERIFICATION',
+                slot: 'VERIFICATION',
+                placeholder:
+                    '해결 여부를 어떻게 검증했으며, 재발 방지를 위해 어떤 대책을 수립했나요?',
+                example:
+                    '부하 테스트 도구로 시뮬레이션하여 응답 속도가 1초 이내로 단축됨을 확인. 이후 슬로우 쿼리 알림 모니터링 시스템 구축',
+            },
+        ],
+    },
+    {
+        sectionKind: SectionKind.PROBLEM_SOLVING,
+        templateId: 'FEEDBACK',
+        label: '피드백 대응',
+        slots: [
+            {
+                slotId: 'PROBLEM_SOLVING.FEEDBACK.RECEIVED',
+                slot: 'RECEIVED',
+                placeholder: '어떤 요청이나 불편 사항, 피드백이 반복적으로 접수되었나요?',
+                example: '사내 비품 신청 과정이 전반적으로 어렵다는 불만이 다수 접수됨',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.FEEDBACK.NEED',
+                slot: 'NEED',
+                placeholder:
+                    '표면적인 의견 뒤에 있는 실제 니즈나 근본적인 문제점은 무엇으로 파악했나요?',
+                example:
+                    '신청 양식 간소화뿐만 아니라, 신청 내역과 투명한 진행 상황 공유가 사용자들의 핵심 니즈임을 파악',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.FEEDBACK.ACTION',
+                slot: 'ACTION',
+                placeholder: '이를 해결하기 위해 구체적으로 어떤 대응책이나 개선안을 실행했나요?',
+                example:
+                    'Notion을 활용하여 신청 양식을 통일하고, 칸반 보드 형태로 처리 상태를 실시간으로 확인 가능하게 개선',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.FEEDBACK.OUTCOME',
+                slot: 'OUTCOME',
+                placeholder: '조치 이후 피드백을 준 대상의 반응이나 상황은 어떻게 달라졌나요?',
+                example:
+                    '비품 신청 관련 중복 문의가 80% 감소했으며, 팀원들로부터 업무 효율성과 투명성이 크게 높아졌다는 긍정적 피드백 확보',
+            },
+        ],
+    },
+    {
+        sectionKind: SectionKind.PROBLEM_SOLVING,
+        templateId: 'RECOVERY',
+        label: '실패 회복',
+        slots: [
+            {
+                slotId: 'PROBLEM_SOLVING.RECOVERY.FAILURE',
+                slot: 'FAILURE',
+                placeholder: '아쉬웠던 결과, 구체적인 실수, 혹은 직면했던 한계는 무엇이었나요?',
+                example:
+                    '첫 프로젝트 진행 시, 아이디어 기획에 과도한 시간을 쏟아 핵심 기능 구현을 기한 내에 마치지 못함',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.RECOVERY.CAUSE',
+                slot: 'CAUSE',
+                placeholder:
+                    '이러한 결과나 실수가 발생하게 된 핵심적인 원인은 무엇이라고 판단했나요?',
+                example:
+                    '완벽한 결과물을 만들고자 하는 욕심으로 인해, MVP 정의와 작업의 우선순위 설정에 실패한 것이 원인',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.RECOVERY.EFFORT',
+                slot: 'EFFORT',
+                placeholder: '이를 극복하고 보완하기 위해 구체적으로 어떤 노력을 했나요?',
+                example:
+                    '애자일 방법론과 스프린트 개념을 학습하고, 다음 프로젝트부터는 핵심 기능 위주로 백로그를 작성하여 일정 관리 방식을 개선',
+            },
+            {
+                slotId: 'PROBLEM_SOLVING.RECOVERY.CHANGE',
+                slot: 'CHANGE',
+                placeholder: '이전과 비교하여 결과가 어떻게 변화했나요?',
+                example:
+                    '두 번째 프로젝트에서는 주어진 기한 내에 성공적으로 프로토타입을 배포하고 사용자 테스트까지 완료하며 목표 달성',
+            },
+        ],
+    },
+];
+
+export const DEFAULT_SUB_TEMPLATE_ID = 'BASIC';
+
+export function getCategorySlotsForSection(sectionKind: SectionKind): CategorySlot[] {
+    return CATEGORY_SLOTS.filter((slot) => slot.sectionKind === sectionKind);
+}
+
+export function getAnchorSlot(sectionKind: SectionKind): CategorySlot | null {
+    return CATEGORY_SLOTS.find((slot) => slot.sectionKind === sectionKind && slot.isAnchor) ?? null;
+}
+
+export function getSubTemplatesForSection(sectionKind: SectionKind): SubTemplate[] {
+    return SUB_TEMPLATES.filter((template) => template.sectionKind === sectionKind);
+}
+
+export function getSubTemplate(sectionKind: SectionKind, templateId: string): SubTemplate | null {
+    return (
+        SUB_TEMPLATES.find(
+            (template) => template.sectionKind === sectionKind && template.templateId === templateId
+        ) ?? null
+    );
+}
+
+export function getDefaultSubTemplate(sectionKind: SectionKind): SubTemplate | null {
+    return getSubTemplate(sectionKind, DEFAULT_SUB_TEMPLATE_ID);
+}

--- a/src/modules/block/presentation/template.controller.ts
+++ b/src/modules/block/presentation/template.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiCommonErrorResponse, ApiCommonResponse } from 'src/common/decorators/swagger.decorator';
+import { ErrorCode } from 'src/common/exceptions/error-code.enum';
+import { TemplateCatalogService } from '../application/services/template-catalog.service';
+import { TemplateCatalogResDTO } from '../application/dtos/template.dto';
+
+@ApiTags('Template')
+@Controller('templates')
+export class TemplateController {
+    constructor(private readonly templateCatalogService: TemplateCatalogService) {}
+
+    @Get()
+    @ApiOperation({
+        summary: '블록 템플릿 카탈로그 조회',
+        description:
+            '섹션별 level 4 카테고리 슬롯과 level 5 하위 템플릿(담당업무/문제해결) 목록을 조회합니다. slot_id, placeholder, 작성 예시를 포함합니다.',
+    })
+    @ApiCommonResponse(TemplateCatalogResDTO)
+    @ApiCommonErrorResponse(ErrorCode.UNAUTHORIZED)
+    getTemplates(): TemplateCatalogResDTO {
+        return this.templateCatalogService.getCatalog();
+    }
+}


### PR DESCRIPTION
## 요약
`feat/block-crud-api` 위에 스택된 PR입니다. 블록 템플릿 정책 문서에 정의된 slot_id 카탈로그를 코드 상수로 관리하고, `GET /templates`로 노출하며, EXPERIENCE 생성 시 기본 템플릿 슬롯을 자동 시딩합니다.

## 변경 사항
- **SectionKind**: DB `block_kind_enum`과 분리된 API 계약용 식별자(`DETAIL`/`ACHIEVEMENT`/`TASK`/`PROBLEM_SOLVING`/`LEARNING`) 추가. DB enum이 바뀌어도 slot_id 계약이 깨지지 않도록 분리
- **템플릿 카탈로그 상수**: level4 카테고리 슬롯 10개(`{SECTION}.{SLOT}`) + level5 하위 템플릿 슬롯 28개(`{SECTION}.{TEMPLATE}.{SLOT}`, 담당업무 1종 + 문제해결 6종 × 4슬롯). DB 참조 무결성이 필요 없는 정적 콘텐츠라 테이블 대신 코드 상수로 관리
- **`GET /templates`**: `sections[].slots`(level4) / `sections[].subTemplates`(level5) / `anchorSlotId` 구조로 카탈로그 응답 (slot_id, placeholder, 작성 예시 포함)
- **EXPERIENCE 생성 시 기본 시딩**: 문서 "1. 기본 제공 데이터" 규칙대로 5개 SECTION 하위에 18개 기본 CONTENT 슬롯(DETAIL 5 + ACHIEVEMENT 2 + TASK 앵커·BASIC 4 + PROBLEM_SOLVING 앵커·BASIC 4 + LEARNING 1)을 빈 content + 지정 placeholder로 자동 생성
- **앵커 placeholder 자동 부여**: 문서 "0. 기본 placeholder" 규칙대로 담당업무/문제해결 섹션 아래 새로 생성되는 4단계 블록은 앵커 슬롯의 placeholder를 자동으로 사용하도록 `createBlock` 수정

## 배포 대상

- [ ] dev

## 참고 사항
- slot_id는 점 개수가 곧 위계입니다 (level4 = 2-part, level5 = 3-part).
- AI 커밋 요청(`ai_experience_request`) 쪽에서의 템플릿 슬롯 검증/적용 로직은 아직 AI 플로우 자체가 없어 이번 스코프에서 제외했습니다.
- 카탈로그 데이터(placeholder/예시 텍스트)는 정책 문서를 그대로 옮긴 것으로, 문서가 갱신되면 `src/modules/block/domain/templates/template-catalog.ts` 동기화가 필요합니다.