### PR TITLE
Feat: 블록 CRUD 변경 시 ai_commit_log 스냅샷 삭제 연결

### DIFF
--- a/src/modules/block/application/facades/experience-map.facade.ts
+++ b/src/modules/block/application/facades/experience-map.facade.ts
@@ -3,6 +3,7 @@ import { Transactional } from 'typeorm-transactional';
 import { BlockService } from '../services/block.service';
 import { ExperienceMapService } from '../services/experience-map.service';
 import { ExperienceMetaService } from '../services/experience-meta.service';
+import { AiCommitLogService } from '../services/ai-commit-log.service';
 import {
     BlockResDTO,
     CreateBlockReqDTO,
@@ -17,7 +18,8 @@ export class ExperienceMapFacade {
     constructor(
         private readonly blockService: BlockService,
         private readonly experienceMapService: ExperienceMapService,
-        private readonly experienceMetaService: ExperienceMetaService
+        private readonly experienceMetaService: ExperienceMetaService,
+        private readonly aiCommitLogService: AiCommitLogService
     ) {}
 
     @Transactional()
@@ -45,6 +47,7 @@ export class ExperienceMapFacade {
             body.content ?? null
         );
         await this.experienceMapService.bumpVersion(experienceMap);
+        await this.aiCommitLogService.discardByUserId(userId);
         return BlockResDTO.fromEntity(block);
     }
 
@@ -58,6 +61,7 @@ export class ExperienceMapFacade {
         this.experienceMapService.assertVersion(experienceMap, body.expectedMapVersion);
         const block = await this.blockService.updateContent(blockId, userId, body.content ?? null);
         await this.experienceMapService.bumpVersion(experienceMap);
+        await this.aiCommitLogService.discardByUserId(userId);
         return BlockResDTO.fromEntity(block);
     }
 
@@ -67,6 +71,7 @@ export class ExperienceMapFacade {
         this.experienceMapService.assertVersion(experienceMap, expectedMapVersion);
         await this.blockService.deleteBlock(blockId, userId);
         await this.experienceMapService.bumpVersion(experienceMap);
+        await this.aiCommitLogService.discardByUserId(userId);
     }
 
     @Transactional()
@@ -80,6 +85,7 @@ export class ExperienceMapFacade {
             body.position
         );
         await this.experienceMapService.bumpVersion(experienceMap);
+        await this.aiCommitLogService.discardByUserId(userId);
         return BlockResDTO.fromEntity(block);
     }
 }

--- a/src/modules/block/application/services/ai-commit-log.service.ts
+++ b/src/modules/block/application/services/ai-commit-log.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { AiCommitLogRepository } from '../../infrastructure/repositories/ai-commit-log.repository';
+
+@Injectable()
+export class AiCommitLogService {
+    constructor(private readonly aiCommitLogRepository: AiCommitLogRepository) {}
+
+    // 사용자가 블록을 직접 수정하면 AI 커밋은 더 이상 되돌릴 수 없으므로,
+    // 되돌리기 대상 기록을 폐기한다 (만료만 기다리는 죽은 데이터로 남기지 않는다).
+    async discardByUserId(userId: number): Promise<void> {
+        await this.aiCommitLogRepository.deleteByUserId(userId);
+    }
+}

--- a/src/modules/block/block.module.ts
+++ b/src/modules/block/block.module.ts
@@ -14,9 +14,11 @@ import { BlockKindRepository } from './infrastructure/repositories/block-kind.re
 import { ExperienceMetaRepository } from './infrastructure/repositories/experience-meta.repository';
 import { ExperienceMapRepository } from './infrastructure/repositories/experience-map.repository';
 import { AiCommitRequestRepository } from './infrastructure/repositories/ai-commit-request.repository';
+import { AiCommitLogRepository } from './infrastructure/repositories/ai-commit-log.repository';
 import { BlockService } from './application/services/block.service';
 import { ExperienceMapService } from './application/services/experience-map.service';
 import { ExperienceMetaService } from './application/services/experience-meta.service';
+import { AiCommitLogService } from './application/services/ai-commit-log.service';
 import { ExperienceMapFacade } from './application/facades/experience-map.facade';
 import { ExperienceMapController } from './presentation/experience-map.controller';
 import { TemplateCatalogService } from './application/services/template-catalog.service';
@@ -43,9 +45,11 @@ import { TemplateController } from './presentation/template.controller';
         ExperienceMetaRepository,
         ExperienceMapRepository,
         AiCommitRequestRepository,
+        AiCommitLogRepository,
         BlockService,
         ExperienceMapService,
         ExperienceMetaService,
+        AiCommitLogService,
         ExperienceMapFacade,
         TemplateCatalogService,
     ],

--- a/src/modules/block/infrastructure/repositories/ai-commit-log.repository.ts
+++ b/src/modules/block/infrastructure/repositories/ai-commit-log.repository.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AiCommitLog } from '../../domain/ai-commit-log.entity';
+
+@Injectable()
+export class AiCommitLogRepository {
+    constructor(
+        @InjectRepository(AiCommitLog)
+        private readonly aiCommitLogRepository: Repository<AiCommitLog>
+    ) {}
+
+    findByUserId(userId: number): Promise<AiCommitLog | null> {
+        return this.aiCommitLogRepository.findOne({ where: { userId } });
+    }
+
+    save(entity: AiCommitLog): Promise<AiCommitLog> {
+        return this.aiCommitLogRepository.save(entity);
+    }
+
+    async deleteByUserId(userId: number): Promise<void> {
+        await this.aiCommitLogRepository.delete({ userId });
+    }
+}


### PR DESCRIPTION
## 요약

 사용자가 에디터에서 블록을 직접 수정하면 AI 커밋을 더 이상 되돌릴 수 없어야 하므로, 기존 CRUD 4곳에 `ai_commit_log` 스냅샷 삭제를 연결합니다.

## 변경 사항

- `ExperienceMapFacade`의 `createBlock`/`updateBlockContent`/`deleteBlock`/`moveBlock` 4개 메서드 전부에 `ai_commit_log` 삭제 연결
- `AiCommitLogRepository`/`AiCommitLogService` 신규 추가

## 배포 대상

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## 관련 이슈

Stacked on #423 (feat/expmap-ai-foundation)

## 참고 사항
N/A