### PR TITLE
Feat: 경험 정리 AI 세션 티켓 발급 API 추가

### DIFF
--- a/src/modules/block/application/dtos/experience-map-ticket.dto.ts
+++ b/src/modules/block/application/dtos/experience-map-ticket.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsUUID } from 'class-validator';
+
+export class IssueTicketReqDTO {
+    @IsOptional()
+    @IsUUID()
+    @ApiProperty({
+        required: false,
+        description:
+            '재시도 시 실패한 요청의 request_id를 그대로 전달하면 새 UUID를 생성하지 않고 재사용합니다.',
+        example: '550e8400-e29b-41d4-a716-446655440000',
+    })
+    request_id?: string;
+}
+
+export class IssueTicketResDTO {
+    @ApiProperty({ description: 'HS256으로 서명된 티켓. sub/sid/iat/exp를 담는다.' })
+    ticket: string;
+
+    @ApiProperty({ description: '사용자의 AI 경험 정리 세션 id' })
+    session_id: string;
+
+    @ApiProperty({ description: '이번 턴의 request_id. 커밋 시 그대로 사용된다.' })
+    request_id: string;
+
+    @ApiProperty({ description: '티켓 만료까지 남은 초' })
+    expires_in: number;
+
+    static from(
+        ticket: string,
+        sessionId: string,
+        requestId: string,
+        expiresIn: number
+    ): IssueTicketResDTO {
+        const dto = new IssueTicketResDTO();
+        dto.ticket = ticket;
+        dto.session_id = sessionId;
+        dto.request_id = requestId;
+        dto.expires_in = expiresIn;
+        return dto;
+    }
+}

--- a/src/modules/block/application/facades/experience-map-ticket.facade.ts
+++ b/src/modules/block/application/facades/experience-map-ticket.facade.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+import { Transactional } from 'typeorm-transactional';
+import { BlockService } from '../services/block.service';
+import { ExperienceMapService } from '../services/experience-map.service';
+import { AiExperienceSessionService } from '../services/ai-experience-session.service';
+import { ExperienceMapTicketService } from '../services/experience-map-ticket.service';
+import { IssueTicketResDTO } from '../dtos/experience-map-ticket.dto';
+import { BlockKind } from '../../domain/enums/block-kind.enum';
+
+const INITIAL_GROUP_CONTENT = '새로운 그룹 1';
+const INITIAL_EXPERIENCE_CONTENT = '새로운 활동 1';
+
+@Injectable()
+export class ExperienceMapTicketFacade {
+    constructor(
+        private readonly blockService: BlockService,
+        private readonly experienceMapService: ExperienceMapService,
+        private readonly aiExperienceSessionService: AiExperienceSessionService,
+        private readonly experienceMapTicketService: ExperienceMapTicketService
+    ) {}
+
+    @Transactional()
+    async issueTicket(userId: number, retryRequestId?: string): Promise<IssueTicketResDTO> {
+        await this.ensureInitialData(userId);
+        const session = await this.aiExperienceSessionService.getOrCreate(userId);
+        const requestId = retryRequestId ?? randomUUID();
+        const { ticket, expiresIn } = this.experienceMapTicketService.issueTicket(
+            userId,
+            session.sessionId
+        );
+        return IssueTicketResDTO.from(ticket, session.sessionId, requestId, expiresIn);
+    }
+
+    // 신규 사용자: 미분류 루트 + 그룹 1 + 활동 1(하위 SECTION 5·기본 CONTENT 슬롯 18개 자동 생성)
+    // = 총 26블록. EXPERIENCE 생성 시 provisionExperienceScaffold가 나머지를 만들어 준다.
+    private async ensureInitialData(userId: number): Promise<void> {
+        const existing = await this.experienceMapService.tryFind(userId);
+        if (existing) {
+            return;
+        }
+
+        await this.blockService.getOrCreateRootBlock(userId);
+        const group = await this.blockService.createBlock(
+            userId,
+            BlockKind.GROUP,
+            null,
+            INITIAL_GROUP_CONTENT
+        );
+        await this.blockService.createBlock(
+            userId,
+            BlockKind.EXPERIENCE,
+            group.id,
+            INITIAL_EXPERIENCE_CONTENT
+        );
+        await this.experienceMapService.getOrCreate(userId);
+    }
+}

--- a/src/modules/block/application/services/ai-experience-session.service.ts
+++ b/src/modules/block/application/services/ai-experience-session.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { AiRelayPort } from 'src/common/ports/ai-relay.port';
+import { AiExperienceSessionRepository } from '../../infrastructure/repositories/ai-experience-session.repository';
+import { AiExperienceSession } from '../../domain/ai-experience-session.entity';
+
+interface CreateSessionAiResponse {
+    session_id: string;
+}
+
+@Injectable()
+export class AiExperienceSessionService {
+    constructor(
+        private readonly aiExperienceSessionRepository: AiExperienceSessionRepository,
+        private readonly aiRelayPort: AiRelayPort
+    ) {}
+
+    async getOrCreate(userId: number): Promise<AiExperienceSession> {
+        const existing = await this.aiExperienceSessionRepository.findByUserId(userId);
+        if (existing) {
+            return existing;
+        }
+
+        const response = await this.aiRelayPort.postJson<CreateSessionAiResponse>({
+            path: '/sessions',
+            body: { user_id: String(userId) },
+        });
+
+        const session = new AiExperienceSession();
+        session.userId = userId;
+        session.sessionId = response.data.session_id;
+        return this.aiExperienceSessionRepository.save(session);
+    }
+}

--- a/src/modules/block/application/services/experience-map-ticket.service.ts
+++ b/src/modules/block/application/services/experience-map-ticket.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+
+const DEFAULT_TICKET_TTL_SECONDS = 300;
+
+interface ExperienceMapTicketPayload {
+    sub: string;
+    sid: string;
+}
+
+export interface IssuedTicket {
+    ticket: string;
+    expiresIn: number;
+}
+
+@Injectable()
+export class ExperienceMapTicketService {
+    constructor(
+        private readonly jwtService: JwtService,
+        private readonly configService: ConfigService
+    ) {}
+
+    issueTicket(userId: number, sessionId: string): IssuedTicket {
+        const expiresIn = Number(
+            this.configService.get<string>('EXPMAP_TICKET_TTL_SECONDS') ??
+                DEFAULT_TICKET_TTL_SECONDS
+        );
+        const payload: ExperienceMapTicketPayload = { sub: String(userId), sid: sessionId };
+        const ticket = this.jwtService.sign(payload, { expiresIn });
+        return { ticket, expiresIn };
+    }
+}

--- a/src/modules/block/application/services/experience-map.service.ts
+++ b/src/modules/block/application/services/experience-map.service.ts
@@ -8,6 +8,10 @@ import { ExperienceMap } from '../../domain/experience-map.entity';
 export class ExperienceMapService {
     constructor(private readonly experienceMapRepository: ExperienceMapRepository) {}
 
+    async tryFind(userId: number): Promise<ExperienceMap | null> {
+        return this.experienceMapRepository.findByUserId(userId);
+    }
+
     async getOrCreate(userId: number): Promise<ExperienceMap> {
         const existing = await this.experienceMapRepository.findByUserId(userId);
         if (existing) {

--- a/src/modules/block/block.module.ts
+++ b/src/modules/block/block.module.ts
@@ -1,5 +1,9 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { StringValue } from 'ms';
+import { AiRelayModule } from 'src/infra/ai-relay/ai-relay.module';
 import { Block } from './domain/block.entity';
 import { BlockKindEntity } from './domain/block-kind.entity';
 import { ExperienceMeta } from './domain/experience-meta.entity';
@@ -19,8 +23,13 @@ import { BlockService } from './application/services/block.service';
 import { ExperienceMapService } from './application/services/experience-map.service';
 import { ExperienceMetaService } from './application/services/experience-meta.service';
 import { AiCommitLogService } from './application/services/ai-commit-log.service';
+import { AiExperienceSessionService } from './application/services/ai-experience-session.service';
+import { ExperienceMapTicketService } from './application/services/experience-map-ticket.service';
+import { AiExperienceSessionRepository } from './infrastructure/repositories/ai-experience-session.repository';
 import { ExperienceMapFacade } from './application/facades/experience-map.facade';
+import { ExperienceMapTicketFacade } from './application/facades/experience-map-ticket.facade';
 import { ExperienceMapController } from './presentation/experience-map.controller';
+import { ExperienceMapAiController } from './presentation/experience-map-ai.controller';
 import { TemplateCatalogService } from './application/services/template-catalog.service';
 import { TemplateController } from './presentation/template.controller';
 
@@ -37,8 +46,22 @@ import { TemplateController } from './presentation/template.controller';
             AiCommitLog,
             AiCommitRequest,
         ]),
+        AiRelayModule,
+        // 티켓 서명 전용 시크릿(EXPMAP_TICKET_SECRET)을 쓰는 별도 JwtService.
+        // auth.module.ts의 JwtModule(JWT_SECRET_TOKEN)과는 모듈 스코프가 분리되어 서로 섞이지 않는다.
+        JwtModule.registerAsync({
+            imports: [ConfigModule],
+            useFactory: (configService: ConfigService) => ({
+                secret: configService.getOrThrow<string>('EXPMAP_TICKET_SECRET'),
+                signOptions: {
+                    expiresIn: (configService.get<string>('EXPMAP_TICKET_TTL_SECONDS') ||
+                        '300') as StringValue,
+                },
+            }),
+            inject: [ConfigService],
+        }),
     ],
-    controllers: [ExperienceMapController, TemplateController],
+    controllers: [ExperienceMapController, ExperienceMapAiController, TemplateController],
     providers: [
         BlockRepository,
         BlockKindRepository,
@@ -46,11 +69,15 @@ import { TemplateController } from './presentation/template.controller';
         ExperienceMapRepository,
         AiCommitRequestRepository,
         AiCommitLogRepository,
+        AiExperienceSessionRepository,
         BlockService,
         ExperienceMapService,
         ExperienceMetaService,
         AiCommitLogService,
+        AiExperienceSessionService,
+        ExperienceMapTicketService,
         ExperienceMapFacade,
+        ExperienceMapTicketFacade,
         TemplateCatalogService,
     ],
 })

--- a/src/modules/block/infrastructure/repositories/ai-experience-session.repository.ts
+++ b/src/modules/block/infrastructure/repositories/ai-experience-session.repository.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AiExperienceSession } from '../../domain/ai-experience-session.entity';
+
+@Injectable()
+export class AiExperienceSessionRepository {
+    constructor(
+        @InjectRepository(AiExperienceSession)
+        private readonly aiExperienceSessionRepository: Repository<AiExperienceSession>
+    ) {}
+
+    findByUserId(userId: number): Promise<AiExperienceSession | null> {
+        return this.aiExperienceSessionRepository.findOne({ where: { userId } });
+    }
+
+    save(entity: AiExperienceSession): Promise<AiExperienceSession> {
+        return this.aiExperienceSessionRepository.save(entity);
+    }
+}

--- a/src/modules/block/presentation/experience-map-ai.controller.ts
+++ b/src/modules/block/presentation/experience-map-ai.controller.ts
@@ -1,0 +1,36 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { SkipTransform } from 'src/common/decorators/skip-transform.decorator';
+import { ApiCommonErrorResponse } from 'src/common/decorators/swagger.decorator';
+import { ErrorCode } from 'src/common/exceptions/error-code.enum';
+import { User } from 'src/common/decorators/user.decorator';
+import { ExperienceMapTicketFacade } from '../application/facades/experience-map-ticket.facade';
+import {
+    IssueTicketReqDTO,
+    IssueTicketResDTO,
+} from '../application/dtos/experience-map-ticket.dto';
+
+@ApiTags('ExperienceMap - AI Integration')
+@Controller('api/v1/experience-map')
+export class ExperienceMapAiController {
+    constructor(private readonly experienceMapTicketFacade: ExperienceMapTicketFacade) {}
+
+    @Post('ticket')
+    @SkipTransform()
+    @ApiOperation({
+        summary: 'AI 경험 정리 세션 티켓 발급',
+        description:
+            '프론트가 AI 서버에 SSE로 직결하기 전에 신원을 발급받습니다. ' +
+            '경험 맵이 없는 사용자는 이 호출에서 초기 데이터(26블록)가 함께 생성됩니다. ' +
+            'AI 세션이 없으면 AI 서버 POST /sessions를 호출해 생성합니다. ' +
+            'request_id를 body로 전달하면 새로 만들지 않고 그대로 재사용합니다(재시도 턴 유지).',
+    })
+    @ApiResponse({ status: 200, type: IssueTicketResDTO })
+    @ApiCommonErrorResponse(ErrorCode.UNAUTHORIZED)
+    async issueTicket(
+        @User('sub') userId: number,
+        @Body() body: IssueTicketReqDTO
+    ): Promise<IssueTicketResDTO> {
+        return this.experienceMapTicketFacade.issueTicket(userId, body.request_id);
+    }
+}


### PR DESCRIPTION
## 요약

`POST /api/v1/experience-map/ticket` — 프론트가 AI 서버에 SSE로 직결하기 전에 신원(티켓)을 발급받는 API.

## 변경 사항

- `POST /api/v1/experience-map/ticket` 구현 (JWT 세션 인증, 기존 `@User('sub')` 재사용)
- 신규 사용자 초기 데이터 생성 — 기존 `BlockService.createBlock`(GROUP → EXPERIENCE)을 재사용해 26블록을 그대로 생성
- `EXPMAP_TICKET_SECRET` 전용 `JwtService`를 `BlockModule`에 별도 등록하여 인증/인가 JwtService와 모듈 스코프 분리
- AI 세션(`ai_experience_session`) 조회/생성 — 없으면 기존 `AiRelayPort.postJson`으로 AI 서버 `POST /sessions` 호출
- 재시도 시 `request_id`를 body로 전달하면 새로 만들지 않고 재사용 (프론트가 명시적으로 전달하는 방식으로 설계)

## 배포 대상

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## 관련 이슈

Stacked on #424 (feat/expmap-editor-crud-ai-log)

## 참고 사항

N/A