### PR TITLE
Feat: AI 서버용 템플릿 카탈로그 조회 API 추가

### DIFF
--- a/src/modules/block/application/dtos/internal-template.dto.ts
+++ b/src/modules/block/application/dtos/internal-template.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class InternalTemplateSlotResDTO {
+    @ApiProperty({ example: 'PROBLEM_SOLVING.TROUBLESHOOTING.SUMMARY' })
+    slotId: string;
+
+    @ApiProperty({ example: 4 })
+    level: number;
+
+    @ApiProperty({ example: '문제해결 에피소드를 한 줄로 요약해 주세요.' })
+    placeholder: string;
+
+    @ApiProperty({ example: '신규 프로모션 페이지 가입 이탈 문제 해결' })
+    example: string;
+}
+
+export class InternalTemplateSubTemplateResDTO {
+    @ApiProperty({ example: 'TROUBLESHOOTING' })
+    templateId: string;
+
+    @ApiProperty({ example: '기술 트러블슈팅' })
+    label: string;
+
+    @ApiProperty({ type: () => [InternalTemplateSlotResDTO] })
+    slots: InternalTemplateSlotResDTO[];
+}
+
+export class InternalTemplateSectionResDTO {
+    @ApiProperty({ example: 'PROBLEM_SOLVING' })
+    sectionId: string;
+
+    @ApiProperty({ example: '문제해결' })
+    label: string;
+
+    @ApiProperty({ required: false, nullable: true, example: 'PROBLEM_SOLVING.SUMMARY' })
+    anchorSlotId: string | null;
+
+    @ApiProperty({ type: () => [InternalTemplateSlotResDTO], description: 'level 4 카테고리 슬롯' })
+    slots: InternalTemplateSlotResDTO[];
+
+    @ApiProperty({
+        type: () => [InternalTemplateSubTemplateResDTO],
+        description: 'level 5 하위 템플릿 (없으면 빈 배열)',
+    })
+    subTemplates: InternalTemplateSubTemplateResDTO[];
+}
+
+export class InternalTemplateCatalogResDTO {
+    @ApiProperty({
+        example: '2026-08-20',
+        description: '문구가 바뀔 때마다 갱신되는 카탈로그 버전',
+    })
+    version: string;
+
+    @ApiProperty({ type: () => [InternalTemplateSectionResDTO] })
+    sections: InternalTemplateSectionResDTO[];
+}

--- a/src/modules/block/application/services/template-catalog.service.ts
+++ b/src/modules/block/application/services/template-catalog.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { SectionKind } from '../../domain/enums/section-kind.enum';
+import { SECTION_KIND_LABEL, SectionKind } from '../../domain/enums/section-kind.enum';
 import {
     getAnchorSlot,
     getCategorySlotsForSection,
     getSubTemplatesForSection,
+    TEMPLATE_CATALOG_VERSION,
 } from '../../domain/templates/template-catalog';
 import {
     TemplateCatalogResDTO,
@@ -11,6 +12,15 @@ import {
     TemplateSlotResDTO,
     TemplateSubTemplateResDTO,
 } from '../dtos/template.dto';
+import {
+    InternalTemplateCatalogResDTO,
+    InternalTemplateSectionResDTO,
+    InternalTemplateSlotResDTO,
+    InternalTemplateSubTemplateResDTO,
+} from '../dtos/internal-template.dto';
+
+const CATEGORY_SLOT_LEVEL = 4;
+const SUB_TEMPLATE_SLOT_LEVEL = 5;
 
 @Injectable()
 export class TemplateCatalogService {
@@ -18,6 +28,16 @@ export class TemplateCatalogService {
         const catalog = new TemplateCatalogResDTO();
         catalog.sections = Object.values(SectionKind).map((sectionKind) =>
             this.buildSection(sectionKind)
+        );
+        return catalog;
+    }
+
+    // AI 서버 전용(X-API-Key). level/label/version 등 AI 계약 필드가 추가로 필요해 별도 DTO로 조립한다.
+    getInternalCatalog(): InternalTemplateCatalogResDTO {
+        const catalog = new InternalTemplateCatalogResDTO();
+        catalog.version = TEMPLATE_CATALOG_VERSION;
+        catalog.sections = Object.values(SectionKind).map((sectionKind) =>
+            this.buildInternalSection(sectionKind)
         );
         return catalog;
     }
@@ -32,6 +52,36 @@ export class TemplateCatalogService {
         section.subTemplates = getSubTemplatesForSection(sectionKind).map((subTemplate) =>
             TemplateSubTemplateResDTO.from(subTemplate)
         );
+        return section;
+    }
+
+    private buildInternalSection(sectionKind: SectionKind): InternalTemplateSectionResDTO {
+        const section = new InternalTemplateSectionResDTO();
+        section.sectionId = sectionKind;
+        section.label = SECTION_KIND_LABEL[sectionKind];
+        section.anchorSlotId = getAnchorSlot(sectionKind)?.slotId ?? null;
+        section.slots = getCategorySlotsForSection(sectionKind).map((slot) => {
+            const dto = new InternalTemplateSlotResDTO();
+            dto.slotId = slot.slotId;
+            dto.level = CATEGORY_SLOT_LEVEL;
+            dto.placeholder = slot.placeholder;
+            dto.example = slot.example;
+            return dto;
+        });
+        section.subTemplates = getSubTemplatesForSection(sectionKind).map((subTemplate) => {
+            const dto = new InternalTemplateSubTemplateResDTO();
+            dto.templateId = subTemplate.templateId;
+            dto.label = subTemplate.label;
+            dto.slots = subTemplate.slots.map((slot) => {
+                const slotDto = new InternalTemplateSlotResDTO();
+                slotDto.slotId = slot.slotId;
+                slotDto.level = SUB_TEMPLATE_SLOT_LEVEL;
+                slotDto.placeholder = slot.placeholder;
+                slotDto.example = slot.example;
+                return slotDto;
+            });
+            return dto;
+        });
         return section;
     }
 }

--- a/src/modules/block/block.module.ts
+++ b/src/modules/block/block.module.ts
@@ -30,6 +30,7 @@ import { ExperienceMapFacade } from './application/facades/experience-map.facade
 import { ExperienceMapTicketFacade } from './application/facades/experience-map-ticket.facade';
 import { ExperienceMapController } from './presentation/experience-map.controller';
 import { ExperienceMapAiController } from './presentation/experience-map-ai.controller';
+import { ExperienceMapInternalController } from './presentation/experience-map-internal.controller';
 import { TemplateCatalogService } from './application/services/template-catalog.service';
 import { TemplateController } from './presentation/template.controller';
 
@@ -61,7 +62,12 @@ import { TemplateController } from './presentation/template.controller';
             inject: [ConfigService],
         }),
     ],
-    controllers: [ExperienceMapController, ExperienceMapAiController, TemplateController],
+    controllers: [
+        ExperienceMapController,
+        ExperienceMapAiController,
+        ExperienceMapInternalController,
+        TemplateController,
+    ],
     providers: [
         BlockRepository,
         BlockKindRepository,

--- a/src/modules/block/domain/enums/section-kind.enum.ts
+++ b/src/modules/block/domain/enums/section-kind.enum.ts
@@ -10,6 +10,14 @@ export enum SectionKind {
     LEARNING = 'LEARNING',
 }
 
+export const SECTION_KIND_LABEL: Readonly<Record<SectionKind, string>> = {
+    [SectionKind.DETAIL]: '상세정보',
+    [SectionKind.ACHIEVEMENT]: '주요성과',
+    [SectionKind.TASK]: '담당업무',
+    [SectionKind.PROBLEM_SOLVING]: '문제해결',
+    [SectionKind.LEARNING]: '배운 점',
+};
+
 export const SECTION_KIND_TO_BLOCK_KIND: Readonly<Record<SectionKind, BlockKind>> = {
     [SectionKind.DETAIL]: BlockKind.SECTION_DETAIL,
     [SectionKind.ACHIEVEMENT]: BlockKind.SECTION_ACHIEVEMENT,

--- a/src/modules/block/domain/templates/template-catalog.ts
+++ b/src/modules/block/domain/templates/template-catalog.ts
@@ -1,5 +1,9 @@
 import { SectionKind } from '../enums/section-kind.enum';
 
+// AI 서버는 이 값을 기동 시 캐시하고 1시간 TTL로 재사용한다.
+// 슬롯 문구(placeholder/example)를 바꿀 때마다 반드시 갱신할 것.
+export const TEMPLATE_CATALOG_VERSION = '2026-08-20';
+
 export interface CategorySlot {
     slotId: string;
     sectionKind: SectionKind;

--- a/src/modules/block/presentation/experience-map-internal.controller.ts
+++ b/src/modules/block/presentation/experience-map-internal.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Public } from 'src/common/decorators/public.decorator';
+import { SkipTransform } from 'src/common/decorators/skip-transform.decorator';
+import { ApiCommonErrorResponse } from 'src/common/decorators/swagger.decorator';
+import { ErrorCode } from 'src/common/exceptions/error-code.enum';
+import { InternalApiKeyGuard } from 'src/common/guards/internal-api-key.guard';
+import { TemplateCatalogService } from '../application/services/template-catalog.service';
+import { InternalTemplateCatalogResDTO } from '../application/dtos/internal-template.dto';
+
+// 경로는 docs/development/INTERNAL_API_PATTERN.md의 `/internal/*` 규칙을 따르지 않고
+// AI 서버와 고정된 계약 경로(`/api/v1/experience-map/*`)를 그대로 쓴다.
+// 인증(X-API-Key)과 컨트롤러 분리(공개 컨트롤러에 섞지 않음) 원칙은 그대로 지킨다.
+@ApiTags('ExperienceMap - Internal (AI)')
+@Controller('api/v1/experience-map')
+export class ExperienceMapInternalController {
+    constructor(private readonly templateCatalogService: TemplateCatalogService) {}
+
+    @Get('templates')
+    @Public()
+    @UseGuards(InternalApiKeyGuard)
+    @SkipTransform()
+    @ApiHeader({
+        name: 'X-API-Key',
+        required: true,
+        description: 'AI 서버 콜백용 내부 API 키 (MAIN_BACKEND_API_KEY)',
+    })
+    @ApiOperation({
+        summary: '블록 템플릿 카탈로그 조회 (AI 서버용)',
+        description:
+            'AI 서버가 기동 시 1회 조회 후 1시간 TTL로 캐시한다. ' +
+            'unknown_slot_id(422) 응답을 받으면 즉시 재조회한다. ' +
+            '문구가 바뀌면 version이 갱신된다.',
+    })
+    @ApiResponse({ status: 200, type: InternalTemplateCatalogResDTO })
+    @ApiCommonErrorResponse(ErrorCode.UNAUTHORIZED)
+    getTemplates(): InternalTemplateCatalogResDTO {
+        return this.templateCatalogService.getInternalCatalog();
+    }
+}


### PR DESCRIPTION
## 요약

`GET /api/v1/experience-map/templates` — AI 서버가 slot_id → placeholder/example을 조회하는 API. 기존 프론트용 `GET /templates`(JWT)와는 별도 컨트롤러/인증(X-API-Key)으로 분리했습니다.

## 변경 사항

- `GET /api/v1/experience-map/templates` 구현 (X-API-Key, `InternalApiKeyGuard` 재사용)
- `TEMPLATE_CATALOG_VERSION` 상수 추가
- 섹션 한글 라벨 매핑(`SECTION_KIND_LABEL`) 추가

## 배포 대상

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## 관련 이슈

Stacked on #425 (feat/expmap-ticket-api)

## 참고 사항

N/A