### PR TITLE
Feat: 경험 맵 AI 커밋 API 구현

### DIFF
--- a/src/modules/block/application/dtos/experience-map-commit.dto.ts
+++ b/src/modules/block/application/dtos/experience-map-commit.dto.ts
@@ -1,0 +1,131 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+    ArrayMinSize,
+    IsArray,
+    IsEnum,
+    IsIn,
+    IsInt,
+    IsOptional,
+    IsString,
+    IsUUID,
+    ValidateNested,
+} from 'class-validator';
+import { SectionKind } from '../../domain/enums/section-kind.enum';
+
+export enum CommitItemAction {
+    ADD = 'add',
+    UPDATE = 'update',
+}
+
+export class CommitItemReqDTO {
+    @IsString()
+    @ApiProperty({ example: 'it_1' })
+    item_id: string;
+
+    @IsIn([CommitItemAction.ADD, CommitItemAction.UPDATE])
+    @ApiProperty({ enum: CommitItemAction })
+    action: CommitItemAction;
+
+    @IsOptional()
+    @IsString()
+    @ApiProperty({ required: false, nullable: true, example: '3021' })
+    parent_id?: string | null;
+
+    @IsOptional()
+    @IsString()
+    @ApiProperty({
+        required: false,
+        nullable: true,
+        description:
+            '같은 요청에서 앞서 정의한 add item을 부모로 쓸 때. 부모가 자식보다 먼저 나와야 한다.',
+    })
+    parent_item_id?: string | null;
+
+    @IsOptional()
+    @IsEnum(SectionKind)
+    @ApiProperty({ required: false, nullable: true, enum: SectionKind })
+    section_kind?: SectionKind | null;
+
+    @IsOptional()
+    @IsString()
+    @ApiProperty({ required: false, nullable: true, example: 'PROBLEM_SOLVING.SUMMARY' })
+    slot_id?: string | null;
+
+    @IsOptional()
+    @IsString()
+    @ApiProperty({ required: false, nullable: true, maxLength: 500 })
+    content?: string | null;
+
+    @IsOptional()
+    @IsString()
+    @ApiProperty({ required: false, nullable: true, description: '같은 부모의 형제. null이면 끝' })
+    after_id?: string | null;
+
+    @IsOptional()
+    @IsString()
+    @ApiProperty({ required: false, description: 'update 시 필수' })
+    target_id?: string;
+}
+
+export class CommitReqDTO {
+    @IsString()
+    @ApiProperty({ example: '123' })
+    user_id: string;
+
+    @IsUUID()
+    @ApiProperty()
+    request_id: string;
+
+    @IsInt()
+    @ApiProperty({ example: 42 })
+    base_map_version: number;
+
+    @IsArray()
+    @ArrayMinSize(1)
+    @ValidateNested({ each: true })
+    @Type(() => CommitItemReqDTO)
+    @ApiProperty({ type: () => [CommitItemReqDTO] })
+    items: CommitItemReqDTO[];
+}
+
+export class CommitAppliedItemResDTO {
+    @ApiProperty({ example: 'it_1' })
+    item_id: string;
+
+    @ApiProperty({ example: '3701' })
+    block_id: string;
+
+    @ApiProperty({ example: '교내 커머스 리뉴얼 > 문제해결' })
+    path: string;
+
+    static of(itemId: string, blockId: string, path: string): CommitAppliedItemResDTO {
+        const dto = new CommitAppliedItemResDTO();
+        dto.item_id = itemId;
+        dto.block_id = blockId;
+        dto.path = path;
+        return dto;
+    }
+}
+
+export class CommitResDTO {
+    @ApiProperty()
+    request_id: string;
+
+    @ApiProperty({ example: 42 })
+    previous_version: number;
+
+    @ApiProperty({ example: 43 })
+    map_version: number;
+
+    @ApiProperty({ type: () => [CommitAppliedItemResDTO] })
+    applied: CommitAppliedItemResDTO[];
+}
+
+export class CommitStatusResDTO {
+    @ApiProperty()
+    committed: boolean;
+
+    @ApiProperty({ required: false, nullable: true, type: () => CommitResDTO })
+    result: CommitResDTO | null;
+}

--- a/src/modules/block/application/facades/experience-map.facade.ts
+++ b/src/modules/block/application/facades/experience-map.facade.ts
@@ -1,9 +1,15 @@
 import { Injectable } from '@nestjs/common';
+import { createHash } from 'node:crypto';
 import { Transactional } from 'typeorm-transactional';
+import { BusinessException } from 'src/common/exceptions/business.exception';
+import { ErrorCode } from 'src/common/exceptions/error-code.enum';
 import { BlockService } from '../services/block.service';
 import { ExperienceMapService } from '../services/experience-map.service';
 import { ExperienceMetaService } from '../services/experience-meta.service';
 import { AiCommitLogService } from '../services/ai-commit-log.service';
+import { BlockCommitService } from '../services/block-commit.service';
+import { AiCommitRequestRepository } from '../../infrastructure/repositories/ai-commit-request.repository';
+import { AiCommitRequest } from '../../domain/ai-commit-request.entity';
 import {
     BlockResDTO,
     CreateBlockReqDTO,
@@ -11,6 +17,7 @@ import {
     MoveBlockReqDTO,
     UpdateBlockContentReqDTO,
 } from '../dtos/block.dto';
+import { CommitReqDTO, CommitResDTO, CommitStatusResDTO } from '../dtos/experience-map-commit.dto';
 import { BlockKind } from '../../domain/enums/block-kind.enum';
 
 @Injectable()
@@ -19,7 +26,9 @@ export class ExperienceMapFacade {
         private readonly blockService: BlockService,
         private readonly experienceMapService: ExperienceMapService,
         private readonly experienceMetaService: ExperienceMetaService,
-        private readonly aiCommitLogService: AiCommitLogService
+        private readonly aiCommitLogService: AiCommitLogService,
+        private readonly blockCommitService: BlockCommitService,
+        private readonly aiCommitRequestRepository: AiCommitRequestRepository
     ) {}
 
     @Transactional()
@@ -87,5 +96,73 @@ export class ExperienceMapFacade {
         await this.experienceMapService.bumpVersion(experienceMap);
         await this.aiCommitLogService.discardByUserId(userId);
         return BlockResDTO.fromEntity(block);
+    }
+
+    @Transactional()
+    async commit(dto: CommitReqDTO): Promise<CommitResDTO> {
+        const userId = Number(dto.user_id);
+        const itemsHash = this.hashItems(dto.items);
+
+        const existingRequest = await this.aiCommitRequestRepository.findByUserIdAndRequestId(
+            userId,
+            dto.request_id
+        );
+        if (existingRequest) {
+            if (existingRequest.itemsHash !== itemsHash) {
+                throw new BusinessException(ErrorCode.EXPERIENCE_MAP_REQUEST_ID_REUSED);
+            }
+            return existingRequest.result as unknown as CommitResDTO;
+        }
+
+        const experienceMap = await this.experienceMapService.findForUpdateOrThrow(userId);
+        if (experienceMap.mapVersion !== String(dto.base_map_version)) {
+            throw new BusinessException(ErrorCode.EXPERIENCE_MAP_VERSION_CONFLICT, {
+                currentMapVersion: experienceMap.mapVersion,
+            });
+        }
+
+        const allBlocks = await this.blockService.getTreeByUserId(userId);
+        const { applied, createdBlockIds, updatedBlocksPreviousContent } =
+            await this.blockCommitService.execute(userId, dto.items, allBlocks);
+
+        const previousVersion = experienceMap.mapVersion;
+        const updatedMap = await this.experienceMapService.bumpVersion(experienceMap);
+
+        const result = new CommitResDTO();
+        result.request_id = dto.request_id;
+        result.previous_version = Number(previousVersion);
+        result.map_version = Number(updatedMap.mapVersion);
+        result.applied = applied;
+
+        await this.aiCommitLogService.recordCommit(userId, {
+            requestId: dto.request_id,
+            previousVersion,
+            committedVersion: updatedMap.mapVersion,
+            createdBlockIds,
+            updatedBlocks: updatedBlocksPreviousContent,
+        });
+
+        const ledgerEntry = new AiCommitRequest();
+        ledgerEntry.userId = userId;
+        ledgerEntry.requestId = dto.request_id;
+        ledgerEntry.itemsHash = itemsHash;
+        ledgerEntry.result = result as unknown as Record<string, unknown>;
+        await this.aiCommitRequestRepository.save(ledgerEntry);
+
+        return result;
+    }
+
+    async getCommitStatus(requestId: string): Promise<CommitStatusResDTO> {
+        const entry = await this.aiCommitRequestRepository.findByRequestId(requestId);
+        const status = new CommitStatusResDTO();
+        status.committed = entry !== null;
+        status.result = entry ? (entry.result as unknown as CommitResDTO) : null;
+        return status;
+    }
+
+    // request_id 재사용 판정 근거. items 배열을 그대로 직렬화해 해시한다
+    // (검증을 통과한 DTO라 필드 순서가 항상 동일하다).
+    private hashItems(items: CommitReqDTO['items']): string {
+        return createHash('sha256').update(JSON.stringify(items)).digest('hex');
     }
 }

--- a/src/modules/block/application/services/ai-commit-log.service.ts
+++ b/src/modules/block/application/services/ai-commit-log.service.ts
@@ -1,5 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { AiCommitLogRepository } from '../../infrastructure/repositories/ai-commit-log.repository';
+import { AiCommitLog } from '../../domain/ai-commit-log.entity';
+
+export interface RecordCommitInput {
+    requestId: string;
+    previousVersion: string;
+    committedVersion: string;
+    createdBlockIds: string[];
+    updatedBlocks: Record<string, string | null>;
+}
 
 @Injectable()
 export class AiCommitLogService {
@@ -9,5 +18,18 @@ export class AiCommitLogService {
     // 되돌리기 대상 기록을 폐기한다 (만료만 기다리는 죽은 데이터로 남기지 않는다).
     async discardByUserId(userId: number): Promise<void> {
         await this.aiCommitLogRepository.deleteByUserId(userId);
+    }
+
+    // 사용자당 최신 1건만 남기는 되돌리기 스냅샷. AI 커밋 시마다 덮어쓴다.
+    async recordCommit(userId: number, input: RecordCommitInput): Promise<void> {
+        const existing = await this.aiCommitLogRepository.findByUserId(userId);
+        const log = existing ?? new AiCommitLog();
+        log.userId = userId;
+        log.requestId = input.requestId;
+        log.previousVersion = input.previousVersion;
+        log.committedVersion = input.committedVersion;
+        log.createdBlockIds = input.createdBlockIds;
+        log.updatedBlocks = input.updatedBlocks;
+        await this.aiCommitLogRepository.save(log);
     }
 }

--- a/src/modules/block/application/services/block-commit.service.ts
+++ b/src/modules/block/application/services/block-commit.service.ts
@@ -1,0 +1,283 @@
+import { Injectable } from '@nestjs/common';
+import { BusinessException } from 'src/common/exceptions/business.exception';
+import { ErrorCode } from 'src/common/exceptions/error-code.enum';
+import { Block, BLOCK_MAX_LEVEL } from '../../domain/block.entity';
+import { BlockKind, EXPERIENCE_SECTION_KINDS } from '../../domain/enums/block-kind.enum';
+import {
+    BLOCK_KIND_TO_SECTION_KIND,
+    SECTION_KIND_LABEL,
+    SECTION_KIND_TO_BLOCK_KIND,
+} from '../../domain/enums/section-kind.enum';
+import { findSlotPlaceholder } from '../../domain/templates/template-catalog';
+import { BlockService } from './block.service';
+import { BlockKindRepository } from '../../infrastructure/repositories/block-kind.repository';
+import { BlockRepository } from '../../infrastructure/repositories/block.repository';
+import {
+    CommitAppliedItemResDTO,
+    CommitItemAction,
+    CommitItemReqDTO,
+} from '../dtos/experience-map-commit.dto';
+
+export interface BlockCommitResult {
+    applied: CommitAppliedItemResDTO[];
+    createdBlockIds: string[];
+    updatedBlocksPreviousContent: Record<string, string | null>;
+}
+
+const ADD_LEVEL_SECTION = 3;
+const ADD_LEVEL_CONTENT_MIN = 4;
+const ADD_LEVEL_CONTENT_MAX = 5;
+const UPDATE_LEVEL_MIN = 4;
+const UPDATE_LEVEL_MAX = 5;
+const EXPERIENCE_LEVEL = 2;
+
+@Injectable()
+export class BlockCommitService {
+    constructor(
+        private readonly blockService: BlockService,
+        private readonly blockRepository: BlockRepository,
+        private readonly blockKindRepository: BlockKindRepository
+    ) {}
+
+    async execute(
+        userId: number,
+        items: CommitItemReqDTO[],
+        allBlocks: Block[]
+    ): Promise<BlockCommitResult> {
+        this.assertTopologicalOrder(items);
+
+        const blockById = new Map(allBlocks.map((block) => [block.id, block]));
+        const blockByItemId = new Map<string, Block>();
+        const dirtyBlocks = new Set<Block>();
+        const applied: CommitAppliedItemResDTO[] = [];
+        const createdBlockIds: string[] = [];
+        const updatedBlocksPreviousContent: Record<string, string | null> = {};
+        let sharedExperienceId: string | null = null;
+
+        for (const item of items) {
+            const block =
+                item.action === CommitItemAction.ADD
+                    ? await this.processAdd(userId, item, blockById, blockByItemId, dirtyBlocks)
+                    : this.processUpdate(item, blockById, updatedBlocksPreviousContent);
+
+            const experienceId = this.resolveExperienceRootId(block, blockById);
+            sharedExperienceId ??= experienceId;
+            if (experienceId !== sharedExperienceId) {
+                throw new BusinessException(ErrorCode.EXPERIENCE_MAP_INVALID_HIERARCHY);
+            }
+
+            if (item.action === CommitItemAction.ADD) {
+                createdBlockIds.push(block.id);
+            }
+            applied.push(
+                CommitAppliedItemResDTO.of(item.item_id, block.id, this.buildPath(block, blockById))
+            );
+        }
+
+        if (dirtyBlocks.size > 0) {
+            await this.blockRepository.saveAll([...dirtyBlocks]);
+        }
+
+        return { applied, createdBlockIds, updatedBlocksPreviousContent };
+    }
+
+    private assertTopologicalOrder(items: CommitItemReqDTO[]): void {
+        const itemIds = new Set(items.map((item) => item.item_id));
+        if (itemIds.size !== items.length) {
+            throw new BusinessException(ErrorCode.EXPERIENCE_MAP_INVALID_HIERARCHY);
+        }
+
+        const seen = new Set<string>();
+        for (const item of items) {
+            if (item.action === CommitItemAction.ADD && item.parent_item_id) {
+                if (!seen.has(item.parent_item_id)) {
+                    throw new BusinessException(ErrorCode.EXPERIENCE_MAP_INVALID_HIERARCHY);
+                }
+            }
+            seen.add(item.item_id);
+        }
+    }
+
+    private async processAdd(
+        userId: number,
+        item: CommitItemReqDTO,
+        blockById: Map<string, Block>,
+        blockByItemId: Map<string, Block>,
+        dirtyBlocks: Set<Block>
+    ): Promise<Block> {
+        const parent = this.resolveParent(item, blockById, blockByItemId);
+        const { level, kind } = this.resolveAddLevelAndKind(parent, item, blockById);
+        this.assertContentValid(item.content);
+        const placeholder = this.resolvePlaceholder(item.slot_id);
+
+        const siblings = this.getSiblings(parent.id, blockById);
+        const block = new Block();
+        block.userId = userId;
+        block.parent = parent;
+        block.parentId = parent.id;
+        block.level = level;
+        block.kind = kind;
+        block.content = item.content ?? null;
+        block.placeholder = placeholder;
+
+        const targetPosition = this.resolveTargetPosition(siblings, item.after_id);
+        this.blockService.insertAtPosition(siblings, block, targetPosition);
+        for (const sibling of siblings) {
+            dirtyBlocks.add(sibling);
+        }
+
+        const savedBlock = await this.blockRepository.save(block);
+        blockById.set(savedBlock.id, savedBlock);
+        blockByItemId.set(item.item_id, savedBlock);
+        return savedBlock;
+    }
+
+    private processUpdate(
+        item: CommitItemReqDTO,
+        blockById: Map<string, Block>,
+        updatedBlocksPreviousContent: Record<string, string | null>
+    ): Block {
+        if (!item.target_id) {
+            throw new BusinessException(ErrorCode.EXPERIENCE_MAP_INVALID_TARGET);
+        }
+        // blockById는 이미 userId로 스코프된 트리라 조회 성공 자체가 소유권 검증이다.
+        const target = blockById.get(item.target_id);
+        if (!target) {
+            throw new BusinessException(ErrorCode.EXPERIENCE_MAP_INVALID_TARGET);
+        }
+        if (target.level < UPDATE_LEVEL_MIN || target.level > UPDATE_LEVEL_MAX) {
+            throw new BusinessException(ErrorCode.EXPERIENCE_MAP_INVALID_HIERARCHY);
+        }
+        this.assertContentValid(item.content);
+
+        updatedBlocksPreviousContent[target.id] = target.content;
+        target.content = item.content ?? null;
+        return target;
+    }
+
+    private resolveParent(
+        item: CommitItemReqDTO,
+        blockById: Map<string, Block>,
+        blockByItemId: Map<string, Block>
+    ): Block {
+        if (item.parent_item_id) {
+            const parent = blockByItemId.get(item.parent_item_id);
+            if (!parent) {
+                throw new BusinessException(ErrorCode.EXPERIENCE_MAP_INVALID_TARGET);
+            }
+            return parent;
+        }
+        if (item.parent_id) {
+            const parent = blockById.get(item.parent_id);
+            if (!parent) {
+                throw new BusinessException(ErrorCode.EXPERIENCE_MAP_INVALID_TARGET);
+            }
+            return parent;
+        }
+        throw new BusinessException(ErrorCode.EXPERIENCE_MAP_INVALID_HIERARCHY);
+    }
+
+    private resolveAddLevelAndKind(
+        parent: Block,
+        item: CommitItemReqDTO,
+        blockById: Map<string, Block>
+    ): { level: number; kind: BlockKind } {
+        const level = parent.level + 1;
+
+        if (level === ADD_LEVEL_SECTION) {
+            if (parent.kind !== BlockKind.EXPERIENCE || !item.section_kind) {
+                throw new BusinessException(ErrorCode.EXPERIENCE_MAP_INVALID_HIERARCHY);
+            }
+            const kind = SECTION_KIND_TO_BLOCK_KIND[item.section_kind];
+            const siblings = this.getSiblings(parent.id, blockById);
+            if (siblings.some((sibling) => sibling.kind === kind)) {
+                throw new BusinessException(ErrorCode.EXPERIENCE_MAP_INVALID_HIERARCHY);
+            }
+            return { level, kind };
+        }
+
+        if (level >= ADD_LEVEL_CONTENT_MIN && level <= ADD_LEVEL_CONTENT_MAX) {
+            const isSectionParent = EXPERIENCE_SECTION_KINDS.includes(parent.kind);
+            const isNestableContentParent =
+                parent.kind === BlockKind.CONTENT && parent.level < BLOCK_MAX_LEVEL;
+            if (!isSectionParent && !isNestableContentParent) {
+                throw new BusinessException(ErrorCode.EXPERIENCE_MAP_INVALID_HIERARCHY);
+            }
+            return { level, kind: BlockKind.CONTENT };
+        }
+
+        throw new BusinessException(ErrorCode.EXPERIENCE_MAP_INVALID_HIERARCHY);
+    }
+
+    private resolveExperienceRootId(block: Block, blockById: Map<string, Block>): string {
+        let current = block;
+        while (current.level > EXPERIENCE_LEVEL) {
+            const parent = current.parentId ? blockById.get(current.parentId) : undefined;
+            if (!parent) {
+                throw new BusinessException(ErrorCode.EXPERIENCE_MAP_INVALID_TARGET);
+            }
+            current = parent;
+        }
+        if (current.level !== EXPERIENCE_LEVEL || current.kind !== BlockKind.EXPERIENCE) {
+            throw new BusinessException(ErrorCode.EXPERIENCE_MAP_INVALID_HIERARCHY);
+        }
+        return current.id;
+    }
+
+    private getSiblings(parentId: string, blockById: Map<string, Block>): Block[] {
+        return Array.from(blockById.values()).filter((block) => block.parentId === parentId);
+    }
+
+    private resolveTargetPosition(siblings: Block[], afterId: string | null | undefined): number {
+        if (afterId === undefined || afterId === null) {
+            return siblings.length;
+        }
+        const sorted = [...siblings].sort((a, b) => a.position - b.position);
+        const index = sorted.findIndex((sibling) => sibling.id === afterId);
+        if (index === -1) {
+            throw new BusinessException(ErrorCode.EXPERIENCE_MAP_INVALID_TARGET);
+        }
+        return index + 1;
+    }
+
+    private resolvePlaceholder(slotId: string | null | undefined): string | null {
+        if (!slotId) {
+            return null;
+        }
+        const placeholder = findSlotPlaceholder(slotId);
+        if (placeholder === null) {
+            throw new BusinessException(ErrorCode.EXPERIENCE_MAP_UNKNOWN_SLOT_ID);
+        }
+        return placeholder;
+    }
+
+    private assertContentValid(content: string | null | undefined): void {
+        if (content == null) {
+            return;
+        }
+        if (content.trim().length === 0 || content.length > 500) {
+            throw new BusinessException(ErrorCode.BLOCK_CONTENT_TOO_LONG, { maxLength: 500 });
+        }
+    }
+
+    private buildPath(block: Block, blockById: Map<string, Block>): string {
+        const segments: string[] = [];
+        let current = block.parentId ? blockById.get(block.parentId) : undefined;
+        while (current && current.level >= EXPERIENCE_LEVEL) {
+            segments.unshift(this.labelOf(current));
+            current = current.parentId ? blockById.get(current.parentId) : undefined;
+        }
+        return segments.join(' > ');
+    }
+
+    private labelOf(block: Block): string {
+        if (block.content) {
+            return block.content;
+        }
+        const sectionKind = BLOCK_KIND_TO_SECTION_KIND.get(block.kind);
+        if (sectionKind) {
+            return SECTION_KIND_LABEL[sectionKind];
+        }
+        return block.placeholder ?? '';
+    }
+}

--- a/src/modules/block/application/services/experience-map.service.ts
+++ b/src/modules/block/application/services/experience-map.service.ts
@@ -12,6 +12,14 @@ export class ExperienceMapService {
         return this.experienceMapRepository.findByUserId(userId);
     }
 
+    async findForUpdateOrThrow(userId: number): Promise<ExperienceMap> {
+        const experienceMap = await this.experienceMapRepository.findByUserIdForUpdate(userId);
+        if (!experienceMap) {
+            throw new BusinessException(ErrorCode.EXPERIENCE_MAP_NOT_INITIALIZED);
+        }
+        return experienceMap;
+    }
+
     async getOrCreate(userId: number): Promise<ExperienceMap> {
         const existing = await this.experienceMapRepository.findByUserId(userId);
         if (existing) {

--- a/src/modules/block/block.module.ts
+++ b/src/modules/block/block.module.ts
@@ -23,6 +23,7 @@ import { BlockService } from './application/services/block.service';
 import { ExperienceMapService } from './application/services/experience-map.service';
 import { ExperienceMetaService } from './application/services/experience-meta.service';
 import { AiCommitLogService } from './application/services/ai-commit-log.service';
+import { BlockCommitService } from './application/services/block-commit.service';
 import { AiExperienceSessionService } from './application/services/ai-experience-session.service';
 import { ExperienceMapTicketService } from './application/services/experience-map-ticket.service';
 import { AiExperienceSessionRepository } from './infrastructure/repositories/ai-experience-session.repository';
@@ -80,6 +81,7 @@ import { TemplateController } from './presentation/template.controller';
         ExperienceMapService,
         ExperienceMetaService,
         AiCommitLogService,
+        BlockCommitService,
         AiExperienceSessionService,
         ExperienceMapTicketService,
         ExperienceMapFacade,

--- a/src/modules/block/domain/ai-commit-request.entity.ts
+++ b/src/modules/block/domain/ai-commit-request.entity.ts
@@ -2,6 +2,7 @@ import { Column, CreateDateColumn, Entity, Index, PrimaryColumn } from 'typeorm'
 
 @Entity('ai_commit_request')
 @Index(['createdAt'])
+@Index(['requestId'])
 export class AiCommitRequest {
     @PrimaryColumn({ name: 'user_id' })
     userId: number;

--- a/src/modules/block/domain/templates/template-catalog.ts
+++ b/src/modules/block/domain/templates/template-catalog.ts
@@ -401,3 +401,20 @@ export function getSubTemplate(sectionKind: SectionKind, templateId: string): Su
 export function getDefaultSubTemplate(sectionKind: SectionKind): SubTemplate | null {
     return getSubTemplate(sectionKind, DEFAULT_SUB_TEMPLATE_ID);
 }
+
+// AI 커밋 API가 slot_id -> placeholder를 부여할 때 쓴다. 카탈로그에 없으면 null(= unknown_slot_id).
+export function findSlotPlaceholder(slotId: string): string | null {
+    const categorySlot = CATEGORY_SLOTS.find((slot) => slot.slotId === slotId);
+    if (categorySlot) {
+        return categorySlot.placeholder;
+    }
+
+    for (const subTemplate of SUB_TEMPLATES) {
+        const slot = subTemplate.slots.find((s) => s.slotId === slotId);
+        if (slot) {
+            return slot.placeholder;
+        }
+    }
+
+    return null;
+}

--- a/src/modules/block/infrastructure/repositories/ai-commit-request.repository.ts
+++ b/src/modules/block/infrastructure/repositories/ai-commit-request.repository.ts
@@ -14,6 +14,12 @@ export class AiCommitRequestRepository {
         return this.aiCommitRequestRepository.findOne({ where: { userId, requestId } });
     }
 
+    // GET /commit/{request_id}는 경로에 user_id가 없다. request_id는 메인 서버가 생성하는
+    // UUID라 사실상 전역 유일하므로 request_id 단독으로 조회한다.
+    findByRequestId(requestId: string): Promise<AiCommitRequest | null> {
+        return this.aiCommitRequestRepository.findOne({ where: { requestId } });
+    }
+
     save(entity: AiCommitRequest): Promise<AiCommitRequest> {
         return this.aiCommitRequestRepository.save(entity);
     }

--- a/src/modules/block/infrastructure/repositories/experience-map.repository.ts
+++ b/src/modules/block/infrastructure/repositories/experience-map.repository.ts
@@ -17,4 +17,13 @@ export class ExperienceMapRepository {
     async findByUserId(userId: number): Promise<ExperienceMap | null> {
         return this.experienceMapRepository.findOne({ where: { userId } });
     }
+
+    // AI 커밋은 한 사용자에게 동시에 여러 건이 들어올 수 있어 낙관적 CAS만으로는 부족하다.
+    // 트랜잭션 안에서 행을 잠가 base_map_version 확인부터 커밋까지를 직렬화한다.
+    async findByUserIdForUpdate(userId: number): Promise<ExperienceMap | null> {
+        return this.experienceMapRepository.findOne({
+            where: { userId },
+            lock: { mode: 'pessimistic_write' },
+        });
+    }
 }

--- a/src/modules/block/presentation/experience-map-ai.controller.ts
+++ b/src/modules/block/presentation/experience-map-ai.controller.ts
@@ -1,7 +1,6 @@
 import { Body, Controller, Post } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { SkipTransform } from 'src/common/decorators/skip-transform.decorator';
-import { ApiCommonErrorResponse } from 'src/common/decorators/swagger.decorator';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiCommonErrorResponse, ApiCommonResponse } from 'src/common/decorators/swagger.decorator';
 import { ErrorCode } from 'src/common/exceptions/error-code.enum';
 import { User } from 'src/common/decorators/user.decorator';
 import { ExperienceMapTicketFacade } from '../application/facades/experience-map-ticket.facade';
@@ -16,7 +15,6 @@ export class ExperienceMapAiController {
     constructor(private readonly experienceMapTicketFacade: ExperienceMapTicketFacade) {}
 
     @Post('ticket')
-    @SkipTransform()
     @ApiOperation({
         summary: 'AI 경험 정리 세션 티켓 발급',
         description:
@@ -25,7 +23,7 @@ export class ExperienceMapAiController {
             'AI 세션이 없으면 AI 서버 POST /sessions를 호출해 생성합니다. ' +
             'request_id를 body로 전달하면 새로 만들지 않고 그대로 재사용합니다(재시도 턴 유지).',
     })
-    @ApiResponse({ status: 200, type: IssueTicketResDTO })
+    @ApiCommonResponse(IssueTicketResDTO)
     @ApiCommonErrorResponse(ErrorCode.UNAUTHORIZED)
     async issueTicket(
         @User('sub') userId: number,

--- a/src/modules/block/presentation/experience-map-internal.controller.ts
+++ b/src/modules/block/presentation/experience-map-internal.controller.ts
@@ -1,12 +1,17 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
-import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { ApiHeader, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Public } from 'src/common/decorators/public.decorator';
-import { SkipTransform } from 'src/common/decorators/skip-transform.decorator';
-import { ApiCommonErrorResponse } from 'src/common/decorators/swagger.decorator';
+import { ApiCommonErrorResponse, ApiCommonResponse } from 'src/common/decorators/swagger.decorator';
 import { ErrorCode } from 'src/common/exceptions/error-code.enum';
 import { InternalApiKeyGuard } from 'src/common/guards/internal-api-key.guard';
 import { TemplateCatalogService } from '../application/services/template-catalog.service';
 import { InternalTemplateCatalogResDTO } from '../application/dtos/internal-template.dto';
+import { ExperienceMapFacade } from '../application/facades/experience-map.facade';
+import {
+    CommitReqDTO,
+    CommitResDTO,
+    CommitStatusResDTO,
+} from '../application/dtos/experience-map-commit.dto';
 
 // 경로는 docs/development/INTERNAL_API_PATTERN.md의 `/internal/*` 규칙을 따르지 않고
 // AI 서버와 고정된 계약 경로(`/api/v1/experience-map/*`)를 그대로 쓴다.
@@ -14,12 +19,14 @@ import { InternalTemplateCatalogResDTO } from '../application/dtos/internal-temp
 @ApiTags('ExperienceMap - Internal (AI)')
 @Controller('api/v1/experience-map')
 export class ExperienceMapInternalController {
-    constructor(private readonly templateCatalogService: TemplateCatalogService) {}
+    constructor(
+        private readonly templateCatalogService: TemplateCatalogService,
+        private readonly experienceMapFacade: ExperienceMapFacade
+    ) {}
 
     @Get('templates')
     @Public()
     @UseGuards(InternalApiKeyGuard)
-    @SkipTransform()
     @ApiHeader({
         name: 'X-API-Key',
         required: true,
@@ -32,9 +39,58 @@ export class ExperienceMapInternalController {
             'unknown_slot_id(422) 응답을 받으면 즉시 재조회한다. ' +
             '문구가 바뀌면 version이 갱신된다.',
     })
-    @ApiResponse({ status: 200, type: InternalTemplateCatalogResDTO })
+    @ApiCommonResponse(InternalTemplateCatalogResDTO)
     @ApiCommonErrorResponse(ErrorCode.UNAUTHORIZED)
     getTemplates(): InternalTemplateCatalogResDTO {
         return this.templateCatalogService.getInternalCatalog();
+    }
+
+    @Post('commit')
+    @Public()
+    @UseGuards(InternalApiKeyGuard)
+    @ApiHeader({
+        name: 'X-API-Key',
+        required: true,
+        description: 'AI 서버 콜백용 내부 API 키 (MAIN_BACKEND_API_KEY)',
+    })
+    @ApiOperation({
+        summary: '경험 맵 커밋 (AI 서버용)',
+        description:
+            '경험 맵 쓰기는 이 API 하나로 모인다. (user_id, request_id) 기준으로 멱등하며, ' +
+            '이미 커밋된 요청은 재실행하지 않고 저장된 결과를 그대로 반환한다. ' +
+            'base_map_version이 현재 값과 다르면 409(map_version_conflict)로 거부한다.',
+    })
+    @ApiCommonResponse(CommitResDTO)
+    @ApiCommonErrorResponse(
+        ErrorCode.UNAUTHORIZED,
+        ErrorCode.EXPERIENCE_MAP_NOT_INITIALIZED,
+        ErrorCode.EXPERIENCE_MAP_VERSION_CONFLICT,
+        ErrorCode.EXPERIENCE_MAP_REQUEST_ID_REUSED,
+        ErrorCode.EXPERIENCE_MAP_INVALID_HIERARCHY,
+        ErrorCode.EXPERIENCE_MAP_INVALID_TARGET,
+        ErrorCode.EXPERIENCE_MAP_UNKNOWN_SLOT_ID
+    )
+    async commit(@Body() body: CommitReqDTO): Promise<CommitResDTO> {
+        return this.experienceMapFacade.commit(body);
+    }
+
+    @Get('commit/:requestId')
+    @Public()
+    @UseGuards(InternalApiKeyGuard)
+    @ApiHeader({
+        name: 'X-API-Key',
+        required: true,
+        description: 'AI 서버 콜백용 내부 API 키 (MAIN_BACKEND_API_KEY)',
+    })
+    @ApiOperation({
+        summary: '커밋 결과 조회 (AI 서버 크래시 복구용)',
+        description:
+            'AI 서버가 커밋 응답을 받기 전에 죽었을 때 실제로 커밋됐는지 확인한다. ' +
+            'committed=false면 재커밋할 수 있다는 뜻이다.',
+    })
+    @ApiCommonResponse(CommitStatusResDTO)
+    @ApiCommonErrorResponse(ErrorCode.UNAUTHORIZED)
+    async getCommitStatus(@Param('requestId') requestId: string): Promise<CommitStatusResDTO> {
+        return this.experienceMapFacade.getCommitStatus(requestId);
     }
 }

--- a/supabase/migrations/20260821090000_add_ai_commit_request_id_index.sql
+++ b/supabase/migrations/20260821090000_add_ai_commit_request_id_index.sql
@@ -1,0 +1,3 @@
+-- GET /experience-map/commit/{request_id}는 경로에 user_id가 없어 request_id 단독으로 조회한다.
+-- request_id는 메인 서버가 생성하는 UUID라 사실상 전역 유일하다.
+CREATE INDEX idx_ai_commit_request_request_id ON ai_commit_request(request_id);


### PR DESCRIPTION
## 요약
경험 맵에 대한 모든 쓰기 API 구현

## 변경 사항

- `POST /commit`: 위계 권한 검증(레벨별 add/update 허용 범위), 소유권/편집가능 검증
- `GET /commit/{requestId}`: AI 서버 크래시 복구용 조회
- `BlockCommitService` 신규 — 커밋 트랜잭션의 핵심 검증/실행 로직

## 배포 대상

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## 관련 이슈

Stacked on #426 (feat/expmap-templates-internal)

## 참고 사항

- ① 멱등성 판정 = `ai_commit_request` 신규 append-only 테이블
- ② request_id 재사용 = 프론트가 명시적으로 전달