### PR TITLE
Feat: AI 커밋 되돌리기 API 구현

### DIFF
--- a/src/modules/block/application/dtos/experience-map-revert.dto.ts
+++ b/src/modules/block/application/dtos/experience-map-revert.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID } from 'class-validator';
+
+export class RevertReqDTO {
+    @IsUUID()
+    @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+    request_id: string;
+}
+
+export class RevertResDTO {
+    @ApiProperty({ example: 44 })
+    map_version: number;
+
+    @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+    reverted_request_id: string;
+
+    static of(mapVersion: number, requestId: string): RevertResDTO {
+        const dto = new RevertResDTO();
+        dto.map_version = mapVersion;
+        dto.reverted_request_id = requestId;
+        return dto;
+    }
+}

--- a/src/modules/block/application/facades/experience-map.facade.ts
+++ b/src/modules/block/application/facades/experience-map.facade.ts
@@ -18,6 +18,7 @@ import {
     UpdateBlockContentReqDTO,
 } from '../dtos/block.dto';
 import { CommitReqDTO, CommitResDTO, CommitStatusResDTO } from '../dtos/experience-map-commit.dto';
+import { RevertResDTO } from '../dtos/experience-map-revert.dto';
 import { BlockKind } from '../../domain/enums/block-kind.enum';
 
 @Injectable()
@@ -150,6 +151,31 @@ export class ExperienceMapFacade {
         await this.aiCommitRequestRepository.save(ledgerEntry);
 
         return result;
+    }
+
+    @Transactional()
+    async revert(userId: number, requestId: string): Promise<RevertResDTO> {
+        const experienceMap = await this.experienceMapService.findForUpdateOrThrow(userId);
+        const log = await this.aiCommitLogService.findRevertibleOrThrow(userId, requestId);
+
+        if (experienceMap.mapVersion !== log.committedVersion) {
+            throw new BusinessException(ErrorCode.EXPERIENCE_MAP_VERSION_CONFLICT, {
+                currentMapVersion: experienceMap.mapVersion,
+            });
+        }
+
+        await this.blockService.deleteByIds(log.createdBlockIds);
+        if (log.updatedBlocks) {
+            await this.blockService.restoreContent(
+                userId,
+                log.updatedBlocks as Record<string, string | null>
+            );
+        }
+
+        const updatedMap = await this.experienceMapService.bumpVersion(experienceMap);
+        await this.aiCommitLogService.discardByUserId(userId);
+
+        return RevertResDTO.of(Number(updatedMap.mapVersion), requestId);
     }
 
     async getCommitStatus(requestId: string): Promise<CommitStatusResDTO> {

--- a/src/modules/block/application/services/ai-commit-log.service.ts
+++ b/src/modules/block/application/services/ai-commit-log.service.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@nestjs/common';
+import { BusinessException } from 'src/common/exceptions/business.exception';
+import { ErrorCode } from 'src/common/exceptions/error-code.enum';
 import { AiCommitLogRepository } from '../../infrastructure/repositories/ai-commit-log.repository';
 import { AiCommitLog } from '../../domain/ai-commit-log.entity';
 
@@ -9,6 +11,8 @@ export interface RecordCommitInput {
     createdBlockIds: string[];
     updatedBlocks: Record<string, string | null>;
 }
+
+const REVERT_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 @Injectable()
 export class AiCommitLogService {
@@ -31,5 +35,17 @@ export class AiCommitLogService {
         log.createdBlockIds = input.createdBlockIds;
         log.updatedBlocks = input.updatedBlocks;
         await this.aiCommitLogRepository.save(log);
+    }
+
+    // 되돌리기 대상 검증: 최신 기록과 request_id가 일치하고, 생성 후 24시간 이내여야 한다.
+    async findRevertibleOrThrow(userId: number, requestId: string): Promise<AiCommitLog> {
+        const log = await this.aiCommitLogRepository.findByUserId(userId);
+        if (!log || log.requestId !== requestId) {
+            throw new BusinessException(ErrorCode.EXPERIENCE_MAP_REVERT_EXPIRED);
+        }
+        if (Date.now() - log.createdAt.getTime() > REVERT_WINDOW_MS) {
+            throw new BusinessException(ErrorCode.EXPERIENCE_MAP_REVERT_EXPIRED);
+        }
+        return log;
     }
 }

--- a/src/modules/block/application/services/block.service.ts
+++ b/src/modules/block/application/services/block.service.ts
@@ -34,6 +34,25 @@ export class BlockService {
         return this.blockRepository.findAllByUserId(userId);
     }
 
+    // 되돌리기: AI 커밋이 새로 만든 블록을 삭제한다. parent_id CASCADE 덕분에
+    // 목록에 조상 id만 있어도 하위 트리가 함께 지워진다.
+    async deleteByIds(blockIds: string[]): Promise<void> {
+        await this.blockRepository.deleteByIds(blockIds);
+    }
+
+    // 되돌리기: AI 커밋이 수정한 블록의 content를 커밋 이전 값으로 복원한다.
+    async restoreContent(
+        userId: number,
+        previousContentByBlockId: Record<string, string | null>
+    ): Promise<void> {
+        const blockIds = Object.keys(previousContentByBlockId);
+        const blocks = await this.blockRepository.findByIdsAndUserId(blockIds, userId);
+        for (const block of blocks) {
+            block.content = previousContentByBlockId[block.id];
+        }
+        await this.blockRepository.saveAll(blocks);
+    }
+
     async getOrCreateRootBlock(userId: number): Promise<Block> {
         const existingRoot = await this.blockRepository.findRootByUserId(userId);
         if (existingRoot) {

--- a/src/modules/block/infrastructure/repositories/block.repository.ts
+++ b/src/modules/block/infrastructure/repositories/block.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { IsNull, Repository } from 'typeorm';
+import { In, IsNull, Repository } from 'typeorm';
 import { Block } from '../../domain/block.entity';
 import { BlockKind } from '../../domain/enums/block-kind.enum';
 
@@ -49,5 +49,21 @@ export class BlockRepository {
 
     async deleteById(id: string): Promise<void> {
         await this.blockRepository.delete(id);
+    }
+
+    async findByIdsAndUserId(ids: string[], userId: number): Promise<Block[]> {
+        if (ids.length === 0) {
+            return [];
+        }
+        return this.blockRepository.find({ where: { id: In(ids), userId } });
+    }
+
+    // parent_id에 ON DELETE CASCADE가 걸려 있어 조상 id 하나만 지워도 하위 트리가 함께 삭제된다.
+    // 목록에 자식 id가 섞여 있어도 이미 지워진 행은 그냥 매칭되지 않을 뿐이라 순서를 신경 쓸 필요 없다.
+    async deleteByIds(ids: string[]): Promise<void> {
+        if (ids.length === 0) {
+            return;
+        }
+        await this.blockRepository.delete(ids);
     }
 }

--- a/src/modules/block/presentation/experience-map-ai.controller.ts
+++ b/src/modules/block/presentation/experience-map-ai.controller.ts
@@ -4,15 +4,20 @@ import { ApiCommonErrorResponse, ApiCommonResponse } from 'src/common/decorators
 import { ErrorCode } from 'src/common/exceptions/error-code.enum';
 import { User } from 'src/common/decorators/user.decorator';
 import { ExperienceMapTicketFacade } from '../application/facades/experience-map-ticket.facade';
+import { ExperienceMapFacade } from '../application/facades/experience-map.facade';
 import {
     IssueTicketReqDTO,
     IssueTicketResDTO,
 } from '../application/dtos/experience-map-ticket.dto';
+import { RevertReqDTO, RevertResDTO } from '../application/dtos/experience-map-revert.dto';
 
 @ApiTags('ExperienceMap - AI Integration')
 @Controller('api/v1/experience-map')
 export class ExperienceMapAiController {
-    constructor(private readonly experienceMapTicketFacade: ExperienceMapTicketFacade) {}
+    constructor(
+        private readonly experienceMapTicketFacade: ExperienceMapTicketFacade,
+        private readonly experienceMapFacade: ExperienceMapFacade
+    ) {}
 
     @Post('ticket')
     @ApiOperation({
@@ -30,5 +35,24 @@ export class ExperienceMapAiController {
         @Body() body: IssueTicketReqDTO
     ): Promise<IssueTicketResDTO> {
         return this.experienceMapTicketFacade.issueTicket(userId, body.request_id);
+    }
+
+    @Post('revert')
+    @ApiOperation({
+        summary: 'AI 커밋 되돌리기',
+        description:
+            '되돌리기도 하나의 변경이라 map_version은 증가한다. 맵 내용만 이전 시점과 같아진다. ' +
+            '최신 AI 커밋이 아니거나 생성 후 24시간이 지나면 되돌릴 수 없다(410). ' +
+            'AI 커밋 뒤 다른 변경으로 버전이 달라졌으면 409.',
+    })
+    @ApiCommonResponse(RevertResDTO)
+    @ApiCommonErrorResponse(
+        ErrorCode.UNAUTHORIZED,
+        ErrorCode.EXPERIENCE_MAP_NOT_INITIALIZED,
+        ErrorCode.EXPERIENCE_MAP_VERSION_CONFLICT,
+        ErrorCode.EXPERIENCE_MAP_REVERT_EXPIRED
+    )
+    async revert(@User('sub') userId: number, @Body() body: RevertReqDTO): Promise<RevertResDTO> {
+        return this.experienceMapFacade.revert(userId, body.request_id);
     }
 }


### PR DESCRIPTION
## 요약

사용자가 AI 커밋 결과를 되돌리는 API 구현

## 변경 사항

- `POST /revert` 구현
- `AiCommitLogService.findRevertibleOrThrow`: 최신 기록 일치 + 24시간 이내 검증
- 되돌리기도 하나의 변경이라 `map_version`은 증가함

## 배포 대상

- [x] Dev (`dev`)
- [ ] Prod (`main`)

## 관련 이슈

Stacked on #427 (feat/expmap-commit-api)

## 참고 사항

N/A